### PR TITLE
Info and Warning messages when adding and removing widgets

### DIFF
--- a/functions/jsonFunctions.py
+++ b/functions/jsonFunctions.py
@@ -60,6 +60,7 @@ def addRemoveWidgets(context, addOrRemove, items, widgets):
 
     activeShape = None
     ob_name = None
+    return_message = ""
     if addOrRemove == 'add':
         bw_widget_prefix = bpy.context.preferences.addons[__package__].preferences.widget_prefix
         for ob in widgets:
@@ -72,11 +73,13 @@ def addRemoveWidgets(context, addOrRemove, items, widgets):
                 widget_items.append(ob_name)
                 wgts[ob_name] = objectDataToDico(ob)
                 activeShape = ob_name
+                return_message = "Widget - " + ob_name + " has been added!"
 
     elif addOrRemove == 'remove':
         del wgts[widgets]
         widget_items.remove(widgets)
         activeShape = widget_items[0]
+        return_message = "Widget - " + widgets + " has been removed!"
 
     if activeShape is not None:
         del bpy.types.Scene.widget_list
@@ -93,5 +96,7 @@ def addRemoveWidgets(context, addOrRemove, items, widgets):
         # trigger an update and display widget
         bpy.context.window_manager.widget_list = bpy.context.window_manager.widget_list
         bpy.context.window_manager.widget_list = activeShape
+
+        return 'INFO', return_message
     elif ob_name is not None:
-        return "Widget - " + ob_name + " already exists!"
+        return 'WARNING', "Widget - " + ob_name + " already exists!"

--- a/operators.py
+++ b/operators.py
@@ -193,7 +193,11 @@ class BONEWIDGET_OT_addWidgets(bpy.types.Operator):
 
         if not objects:
             self.report({'INFO'}, 'Select Meshes or Pose_bones')
-        addRemoveWidgets(context, "add", bpy.types.Scene.widget_list.keywords['items'], objects)
+        #addRemoveWidgets(context, "add", bpy.types.Scene.widget_list.keywords['items'], objects)
+        message_type, return_message = addRemoveWidgets(context, "add", bpy.types.Scene.widget_list.keywords['items'], objects)
+
+        if return_message:
+            self.report({message_type}, return_message)
 
         return {'FINISHED'}
 
@@ -205,7 +209,12 @@ class BONEWIDGET_OT_removeWidgets(bpy.types.Operator):
 
     def execute(self, context):
         objects = bpy.context.window_manager.widget_list
-        unwantedList = addRemoveWidgets(context, "remove", bpy.types.Scene.widget_list.keywords['items'], objects)
+        #unwantedList = addRemoveWidgets(context, "remove", bpy.types.Scene.widget_list.keywords['items'], objects)
+        message_type, return_message = addRemoveWidgets(context, "remove", bpy.types.Scene.widget_list.keywords['items'], objects)
+
+        if return_message:
+            self.report({message_type}, return_message)
+            
         return {'FINISHED'}
 
 


### PR DESCRIPTION
When playing around with the add-on I noticed there were no indication whether, for example, a user widget was successfully added to the list or not. Unless you open up the widget previews and try to find it in the list.

Now the add-on will display an info message at the bottom when something was successfully added or removed,
and also a warning message when the widget failed to be added.