### PR TITLE
Added Advanced options to Redo Panel and other small fixes

### DIFF
--- a/functions/__init__.py
+++ b/functions/__init__.py
@@ -1,2 +1,3 @@
 from .mainFunctions import *
 from .jsonFunctions import *
+from .previewFunctions import *

--- a/functions/mainFunctions.py
+++ b/functions/mainFunctions.py
@@ -125,8 +125,8 @@ def createWidget(bone, widget, relative, size, scale, slide, rotation, collectio
         boneLength = (1 / bone.bone.length)
 
     # add the verts
-    newData.from_pydata(numpy.array(widget['vertices']) * [size * scale[0] * boneLength, size * scale[2]
-                        * boneLength, size * scale[1] * boneLength], widget['edges'], widget['faces'])
+    newData.from_pydata(numpy.array(widget['vertices']) * [size[0] * scale[0] * boneLength, size[1] * scale[2]
+                        * boneLength, size[2] * scale[1] * boneLength], widget['edges'], widget['faces'])
 
     # Create tranform matrices (slide vector and rotation)
     widget_matrix = Matrix()

--- a/functions/mainFunctions.py
+++ b/functions/mainFunctions.py
@@ -130,7 +130,7 @@ def createWidget(bone, widget, relative, size, scale, slide, rotation, collectio
 
     # Create tranform matrices (slide vector and rotation)
     widget_matrix = Matrix()
-    trans = Matrix.Translation((0, slide, 0))
+    trans = Matrix.Translation(slide)
     rot = rotation.to_matrix().to_4x4()
 
     # Translate then rotate the matrix

--- a/functions/previewFunctions.py
+++ b/functions/previewFunctions.py
@@ -1,0 +1,49 @@
+import bpy
+import bpy.utils.previews
+from .jsonFunctions import readWidgets
+import os
+
+
+preview_collections = {}
+
+def generate_previews():
+    enum_items = []
+
+    pcoll = preview_collections["widgets"]
+    if pcoll.widget_list:
+        return pcoll.widget_list
+    
+    #directory = os.path.join(os.path.dirname(__file__), "thumbnails")
+    directory = os.path.abspath(os.path.join(os.path.dirname( __file__ ), '..', 'thumbnails'))
+
+    if directory and os.path.exists(directory):
+        widget_names = sorted(readWidgets())
+
+        for i, name in enumerate(widget_names):
+            filepath = os.path.join(directory, name + ".png")
+
+            icon = pcoll.get(name)
+            if not icon:
+                thumb = pcoll.load(name, filepath, 'IMAGE')
+            else:
+                thumb = pcoll[name]
+            enum_items.append((name, name, "", thumb.icon_id, i))
+
+    pcoll.widget_list = enum_items
+    return enum_items
+
+
+def preview_update(self, context):
+    if len(bpy.types.Scene.widget_list.keywords["items"]) != len(bpy.types.WindowManager.widget_list.keywords["items"]):
+        del bpy.types.WindowManager.widget_list
+        for pcoll in preview_collections.values():
+            bpy.utils.previews.remove(pcoll)
+        preview_collections.clear()
+
+        pcoll = bpy.utils.previews.new()
+        pcoll.widget_list = ()
+        preview_collections["widgets"] = pcoll
+        
+        bpy.types.WindowManager.widget_list = bpy.props.EnumProperty(
+            items=generate_previews(), name="Shape", description="Shape", update=preview_update
+        )

--- a/operators.py
+++ b/operators.py
@@ -41,19 +41,35 @@ class BONEWIDGET_OT_createWidget(bpy.types.Operator):
         description="Scale Widget to bone length"
     )
 
+    advanced_options: BoolProperty(
+        name="Advanced options",
+        default=False,
+        description="Show advanced options"
+    )
+
     global_size: FloatProperty(
         name="Global Size",
         default=1.0,
         description="Global Size"
     )
 
-    slide: FloatProperty(
+    slide_simple: FloatProperty(
         name="Slide",
         default=0.0,
         subtype='NONE',
         unit='NONE',
-        description="Slide widget along y axis"
+        description="Slide widget along bone y axis"
     )
+
+    slide_advanced: FloatVectorProperty(
+        name="Slide",
+        default=(0.0, 0.0, 0.0),
+        subtype='XYZ',
+        unit='NONE',
+        precision=1,
+        description="Slide widget along bone xyz axes"
+    )
+    
     rotation: FloatVectorProperty(
         name="Rotation",
         description="Rotate the widget",
@@ -72,15 +88,18 @@ class BONEWIDGET_OT_createWidget(bpy.types.Operator):
         row = col.row(align=True)
         row.prop(self, "global_size", expand=False)
         row = col.row(align=True)
-        row.prop(self, "slide")
+        row.prop(self, "slide_advanced" if self.advanced_options else "slide_simple", text="Slide")
         row = col.row(align=True)
         row.prop(self, "rotation", text="Rotation")
+        row = col.row(align=True)
+        row.prop(self, "advanced_options")
 
     def execute(self, context):
         wgts = readWidgets()
+        slide = self.slide_advanced if self.advanced_options else (0.0, self.slide_simple, 0.0)
         for bone in bpy.context.selected_pose_bones:
             createWidget(bone, wgts[context.window_manager.widget_list], self.relative_size, self.global_size, [
-                         1, 1, 1], self.slide, self.rotation, getCollection(context))
+                         1, 1, 1], slide, self.rotation, getCollection(context))
         return {'FINISHED'}
 
 

--- a/operators.py
+++ b/operators.py
@@ -25,6 +25,15 @@ from bpy.types import Operator
 from bpy.props import FloatProperty, BoolProperty, FloatVectorProperty
 
 
+def advanced_options_toggled(self, context):
+    if self.advanced_options:
+        self.global_size_advanced = (self.global_size_simple,) * 3
+        self.slide_advanced[1] = self.slide_simple
+    else:
+        self.global_size_simple = self.global_size_advanced[1]
+        self.slide_simple = self.slide_advanced[1]
+
+
 class BONEWIDGET_OT_createWidget(bpy.types.Operator):
     """Creates a widget for selected bone"""
     bl_idname = "bonewidget.create_widget"
@@ -44,7 +53,8 @@ class BONEWIDGET_OT_createWidget(bpy.types.Operator):
     advanced_options: BoolProperty(
         name="Advanced options",
         default=False,
-        description="Show advanced options"
+        description="Show advanced options",
+        update=advanced_options_toggled
     )
 
     global_size_simple: FloatProperty(
@@ -73,7 +83,6 @@ class BONEWIDGET_OT_createWidget(bpy.types.Operator):
         default=(0.0, 0.0, 0.0),
         subtype='XYZ',
         unit='NONE',
-        precision=1,
         description="Slide widget along bone xyz axes"
     )
     

--- a/operators.py
+++ b/operators.py
@@ -47,9 +47,16 @@ class BONEWIDGET_OT_createWidget(bpy.types.Operator):
         description="Show advanced options"
     )
 
-    global_size: FloatProperty(
+    global_size_simple: FloatProperty(
         name="Global Size",
         default=1.0,
+        description="Global Size"
+    )
+
+    global_size_advanced: FloatVectorProperty(
+        name="Global Size",
+        default=(1.0, 1.0, 1.0),
+        subtype='XYZ',
         description="Global Size"
     )
 
@@ -86,7 +93,7 @@ class BONEWIDGET_OT_createWidget(bpy.types.Operator):
         row = col.row(align=True)
         row.prop(self, "relative_size")
         row = col.row(align=True)
-        row.prop(self, "global_size", expand=False)
+        row.prop(self, "global_size_advanced" if self.advanced_options else "global_size_simple", expand=False)
         row = col.row(align=True)
         row.prop(self, "slide_advanced" if self.advanced_options else "slide_simple", text="Slide")
         row = col.row(align=True)
@@ -97,8 +104,9 @@ class BONEWIDGET_OT_createWidget(bpy.types.Operator):
     def execute(self, context):
         wgts = readWidgets()
         slide = self.slide_advanced if self.advanced_options else (0.0, self.slide_simple, 0.0)
+        global_size = self.global_size_advanced if self.advanced_options else (self.global_size_simple,) * 3
         for bone in bpy.context.selected_pose_bones:
-            createWidget(bone, wgts[context.window_manager.widget_list], self.relative_size, self.global_size, [
+            createWidget(bone, wgts[context.window_manager.widget_list], self.relative_size, global_size, [
                          1, 1, 1], slide, self.rotation, getCollection(context))
         return {'FINISHED'}
 

--- a/operators.py
+++ b/operators.py
@@ -325,8 +325,3 @@ def unregister():
     for cls in classes:
         unregister_class(cls)
 
-    try:
-        import os
-        os.remove(os.path.join(os.path.expanduser("~"), "temp.txt"))
-    except:
-        pass

--- a/panels.py
+++ b/panels.py
@@ -1,54 +1,16 @@
 import bpy
 import bpy.utils.previews
-import os
 from .functions import (
     readWidgets,
     getViewLayerCollection,
     recurLayerCollection,
+    preview_collections,
+    generate_previews,
+    preview_update,
 )
 
 from .menus import BONEWIDGET_MT_bw_specials
 
-
-preview_collections = {}
-
-def generate_previews():
-    enum_items = []
-
-    pcoll = preview_collections["widgets"]
-    if pcoll.widget_list:
-        return pcoll.widget_list
-    
-    directory = os.path.join(os.path.dirname(__file__), "thumbnails")
-    if directory and os.path.exists(directory):
-        widget_names = sorted(readWidgets())
-
-        for i, name in enumerate(widget_names):
-            filepath = os.path.join(directory, name + ".png")
-            icon = pcoll.get(name)
-            if not icon:
-                thumb = pcoll.load(name, filepath, 'IMAGE')
-            else:
-                thumb = pcoll[name]
-            enum_items.append((name, name, "", thumb.icon_id, i))
-
-    pcoll.widget_list = enum_items
-    return enum_items
-
-def preview_update(self, context):
-    if len(bpy.types.Scene.widget_list.keywords["items"]) != len(bpy.types.WindowManager.widget_list.keywords["items"]):
-        del bpy.types.WindowManager.widget_list
-        for pcoll in preview_collections.values():
-            bpy.utils.previews.remove(pcoll)
-        preview_collections.clear()
-
-        pcoll = bpy.utils.previews.new()
-        pcoll.widget_list = ()
-        preview_collections["widgets"] = pcoll
-        
-        bpy.types.WindowManager.widget_list = bpy.props.EnumProperty(
-            items=generate_previews(), name="Shape", description="Shape", update=preview_update
-        )
 
 class BONEWIDGET_PT_bw_panel:
     """BoneWidget Addon UI"""


### PR DESCRIPTION
Quick Summary:

- Removed legacy code that deletes a 'temp.txt' file on the users hard drive. Never a good idea to mess with files outside the add-on environment unless user is aware of it.
- Moved the preview functions to its own file
- Added advanced options for the redo panel.
- Split the slice and scale into 3 axes
- synced the y axis values between simple and advanced options

The only thing I'm not totally happy about is how the sync is handled for the scaling...