### PR TITLE
Import and Export User Widgets and other Goodies

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -46,7 +46,6 @@ else:
     from . import menus
 
 import bpy
-import os
 
 
 def get_user_preferences(context):

--- a/functions/jsonFunctions.py
+++ b/functions/jsonFunctions.py
@@ -102,8 +102,9 @@ def addRemoveWidgets(context, addOrRemove, items, widgets, widget_name=""):
         
         del wgts[widgets]
         if widgets in widget_items:
+            widget_index = widget_items.index(widgets)
+            activeShape = widget_items[widget_index + 1] if widget_index == 0 else widget_items[widget_index - 1]
             widget_items.remove(widgets)
-        activeShape = widget_items[0]
         return_message = "Widget - " + widgets + " has been removed!"
 
     if activeShape is not None:

--- a/functions/jsonFunctions.py
+++ b/functions/jsonFunctions.py
@@ -107,19 +107,15 @@ def addRemoveWidgets(context, addOrRemove, items, widgets, widget_name=""):
         return_message = "Widget - " + widgets + " has been removed!"
 
     if activeShape is not None:
-        del bpy.types.Scene.widget_list
 
-        widget_itemsSorted = []
-        for w in sorted(widget_items):
-            widget_itemsSorted.append((w, w, ""))
-
-        bpy.types.Scene.widget_list = bpy.props.EnumProperty(
-            items=widget_itemsSorted, name="Shape", description="Shape")
-        bpy.context.scene.widget_list = activeShape
         writeWidgets(wgts, file)
 
+        # to handle circular import error
+        from .functions import createPreviewCollection
+
+        createPreviewCollection()
+    
         # trigger an update and display widget
-        bpy.context.window_manager.widget_list = bpy.context.window_manager.widget_list
         bpy.context.window_manager.widget_list = activeShape
 
         return 'INFO', return_message

--- a/functions/jsonFunctions.py
+++ b/functions/jsonFunctions.py
@@ -101,7 +101,8 @@ def addRemoveWidgets(context, addOrRemove, items, widgets, widget_name=""):
             wgts = readWidgets(file)
         
         del wgts[widgets]
-        widget_items.remove(widgets)
+        if widgets in widget_items:
+            widget_items.remove(widgets)
         activeShape = widget_items[0]
         return_message = "Widget - " + widgets + " has been removed!"
 
@@ -124,3 +125,46 @@ def addRemoveWidgets(context, addOrRemove, items, widgets, widget_name=""):
         return 'INFO', return_message
     elif ob_name is not None:
         return 'WARNING', "Widget - " + ob_name + " already exists!"
+
+
+def exportWidgetLibrary(filepath):
+    wgts = readWidgets(JSON_USER_WIDGETS)
+
+    if wgts:
+        if not filepath.endswith(".bwl"):
+            filename += ".bwl"
+        f = open(os.path.join(filepath), 'w')
+        f.write(json.dumps(wgts))
+        f.close()
+
+    return len(wgts)
+
+
+def importWidgetLibrary(filepath):
+    wgts = {}
+    num_new_widgets = 0
+    failed_imports = []
+
+    if os.path.exists(filepath):
+        try:
+            f = open(filepath, 'r')
+            wgts = json.load(f)
+            f.close()
+
+            current_wgts = readWidgets(JSON_USER_WIDGETS)
+
+            # check for duplicate names
+            for name, data in wgts.items():
+                if name not in current_wgts:
+                    current_wgts.update({name : data})
+                    num_new_widgets += 1
+                else:
+                    failed_imports.append(name)
+
+            # if there are new widgets
+            if num_new_widgets:
+                writeWidgets(current_wgts, JSON_USER_WIDGETS)
+        except:
+            pass
+
+    return num_new_widgets, failed_imports

--- a/functions/mainFunctions.py
+++ b/functions/mainFunctions.py
@@ -2,7 +2,6 @@ import bpy
 import numpy
 from math import pi
 from mathutils import Matrix
-from .jsonFunctions import objectDataToDico
 from .. import __package__
 
 

--- a/functions/previewFunctions.py
+++ b/functions/previewFunctions.py
@@ -6,6 +6,23 @@ from .. import __package__
 
 preview_collections = {}
 
+
+def createPreviewCollection():
+    if preview_collections:
+        del bpy.types.WindowManager.widget_list
+        for pcoll in preview_collections.values():
+            bpy.utils.previews.remove(pcoll)
+        preview_collections.clear()
+
+    pcoll = bpy.utils.previews.new()
+    pcoll.widget_list = ()
+    preview_collections["widgets"] = pcoll
+
+    bpy.types.WindowManager.widget_list = bpy.props.EnumProperty(
+        items=generate_previews(), name="Shape", description="Shape", update=preview_update
+    )
+
+
 def generate_previews():
     enum_items = []
 
@@ -41,18 +58,7 @@ def generate_previews():
 
 def preview_update(self, context):
     if len(bpy.types.Scene.widget_list.keywords["items"]) != len(bpy.types.WindowManager.widget_list.keywords["items"]):
-        del bpy.types.WindowManager.widget_list
-        for pcoll in preview_collections.values():
-            bpy.utils.previews.remove(pcoll)
-        preview_collections.clear()
-
-        pcoll = bpy.utils.previews.new()
-        pcoll.widget_list = ()
-        preview_collections["widgets"] = pcoll
-        
-        bpy.types.WindowManager.widget_list = bpy.props.EnumProperty(
-            items=generate_previews(), name="Shape", description="Shape", update=preview_update
-        )
+        createPreviewCollection()
 
 
 def get_preview_default():

--- a/functions/previewFunctions.py
+++ b/functions/previewFunctions.py
@@ -57,8 +57,7 @@ def generate_previews():
 
 
 def preview_update(self, context):
-    if len(bpy.types.Scene.widget_list.keywords["items"]) != len(bpy.types.WindowManager.widget_list.keywords["items"]):
-        createPreviewCollection()
+    createPreviewCollection()
 
 
 def get_preview_default():

--- a/functions/previewFunctions.py
+++ b/functions/previewFunctions.py
@@ -57,7 +57,7 @@ def generate_previews():
 
 
 def preview_update(self, context):
-    createPreviewCollection()
+    generate_previews()
 
 
 def get_preview_default():

--- a/menus.py
+++ b/menus.py
@@ -8,6 +8,9 @@ class BONEWIDGET_MT_bw_specials(Menu):
         layout.operator("bonewidget.add_widgets", icon="ADD", text="Add Widget to library")
         layout.operator("bonewidget.remove_widgets", icon="REMOVE",
                         text="Remove Widget from library")
+        layout.separator()
+        layout.operator("bonewidget.import_library", icon="IMPORT", text="Import Widget Library")
+        layout.operator("bonewidget.export_library", icon="EXPORT", text="Export Widget Library")
 
 
 classes = (

--- a/menus.py
+++ b/menus.py
@@ -1,4 +1,3 @@
-import bpy
 from bpy.types import Menu
 
 class BONEWIDGET_MT_bw_specials(Menu):

--- a/operators.py
+++ b/operators.py
@@ -254,8 +254,7 @@ class BONEWIDGET_OT_addWidgets(bpy.types.Operator):
         if not objects:
             self.report({'WARNING'}, 'Select Meshes or Pose bones')
             return {'CANCELLED'}
-        #addRemoveWidgets(context, "add", bpy.types.Scene.widget_list.keywords['items'], objects)
-        message_type, return_message = addRemoveWidgets(context, "add", bpy.types.Scene.widget_list.keywords['items'], objects, self.widget_name)
+        message_type, return_message = addRemoveWidgets(context, "add", bpy.types.WindowManager.widget_list.keywords['items'], objects, self.widget_name)
 
         if return_message:
             self.report({message_type}, return_message)
@@ -270,8 +269,7 @@ class BONEWIDGET_OT_removeWidgets(bpy.types.Operator):
 
     def execute(self, context):
         objects = bpy.context.window_manager.widget_list
-        #unwantedList = addRemoveWidgets(context, "remove", bpy.types.Scene.widget_list.keywords['items'], objects)
-        message_type, return_message = addRemoveWidgets(context, "remove", bpy.types.Scene.widget_list.keywords['items'], objects)
+        message_type, return_message = addRemoveWidgets(context, "remove", bpy.types.WindowManager.widget_list.keywords['items'], objects)
 
         if return_message:
             self.report({message_type}, return_message)

--- a/operators.py
+++ b/operators.py
@@ -17,6 +17,9 @@ from .functions import (
     clearBoneWidgets,
     resyncWidgetNames,
     addObjectAsWidget,
+    importWidgetLibrary,
+    exportWidgetLibrary,
+    createPreviewCollection,
 )
 
 from bpy.props import FloatProperty, BoolProperty, FloatVectorProperty, StringProperty
@@ -276,6 +279,82 @@ class BONEWIDGET_OT_removeWidgets(bpy.types.Operator):
         return {'FINISHED'}
 
 
+class BONEWIDGET_OT_importLibrary(bpy.types.Operator):
+    """Import User Defined Widgets"""
+    bl_idname = "bonewidget.import_library"
+    bl_label = "Import Library"
+
+
+    filter_glob: StringProperty(
+        default='*.bwl',
+        options={'HIDDEN'}
+    )
+
+    filename: StringProperty(
+        name='Filename',
+        description='Name of file to be imported',
+    )
+
+    filepath: StringProperty(
+        subtype="FILE_PATH"
+    )
+
+    def execute(self, context):
+        if self.filepath:
+            num_widgets, failed_imports = importWidgetLibrary(self.filepath)
+
+            if failed_imports:
+                failed = " | ".join(failed_imports)
+                message = f"{num_widgets} widgets imported. {len(failed_imports)} failed: {failed}"
+            else:
+                message = f"{num_widgets} widgets imported successfully!"
+                
+            self.report({'INFO'}, message)
+
+            # trigger an update and display the new widgets if any widgets were imported
+            if num_widgets:
+                createPreviewCollection()
+            
+        return {'FINISHED'}
+
+    def invoke(self, context, event):
+        self.filename = ""
+        context.window_manager.fileselect_add(self)        
+        return {'RUNNING_MODAL'}
+
+
+class BONEWIDGET_OT_exportLibrary(bpy.types.Operator):
+    """Export User Defined Widgets"""
+    bl_idname = "bonewidget.export_library"
+    bl_label = "Export Library"
+
+
+    filter_glob: StringProperty(
+        default='*.bwl',
+        options={'HIDDEN'}
+    )
+    
+    filename: StringProperty(
+        name='Filename',
+        description='Name of file to be exported',
+    )
+
+    filepath: StringProperty(
+        subtype="FILE_PATH"
+    )
+
+    def execute(self, context):
+        if self.filepath:
+            num_widgets = exportWidgetLibrary(self.filepath)
+            self.report({'INFO'}, f"{num_widgets} widgets exported successfully!")
+        return {'FINISHED'}
+
+    def invoke(self, context, event):
+        self.filename = "widgetLibrary.bwl"
+        context.window_manager.fileselect_add(self)
+        return {'RUNNING_MODAL'}
+
+
 class BONEWIDGET_OT_toggleCollectionVisibility(bpy.types.Operator):
     """Show/hide the bone widget collection"""
     bl_idname = "bonewidget.toggle_collection_visibilty"
@@ -359,6 +438,8 @@ class BONEWIDGET_OT_addObjectAsWidget(bpy.types.Operator):
 classes = (
     BONEWIDGET_OT_removeWidgets,
     BONEWIDGET_OT_addWidgets,
+    BONEWIDGET_OT_importLibrary,
+    BONEWIDGET_OT_exportLibrary,
     BONEWIDGET_OT_matchSymmetrizeShape,
     BONEWIDGET_OT_matchBoneTransforms,
     BONEWIDGET_OT_returnToArmature,

--- a/operators.py
+++ b/operators.py
@@ -3,8 +3,6 @@ import bpy
 from .functions import (
     findMatchBones,
     fromWidgetFindBone,
-    findMirrorObject,
-    symmetrizeWidget,
     symmetrizeWidget_helper,
     boneMatrix,
     createWidget,
@@ -12,7 +10,6 @@ from .functions import (
     returnToArmature,
     addRemoveWidgets,
     readWidgets,
-    objectDataToDico,
     getCollection,
     getViewLayerCollection,
     recurLayerCollection,
@@ -21,7 +18,7 @@ from .functions import (
     resyncWidgetNames,
     addObjectAsWidget,
 )
-from bpy.types import Operator
+
 from bpy.props import FloatProperty, BoolProperty, FloatVectorProperty, StringProperty
 
 

--- a/panels.py
+++ b/panels.py
@@ -5,7 +5,7 @@ from .functions import (
     recurLayerCollection,
     preview_collections,
     generate_previews,
-    preview_update,
+    createPreviewCollection,
     get_preview_default,
 )
 
@@ -31,13 +31,7 @@ class BONEWIDGET_PT_bw_panel_main(BONEWIDGET_PT_bw_panel, bpy.types.Panel):
     bpy.types.Scene.widget_list = bpy.props.EnumProperty(
         items=itemsSort, name="Shape", description="Shape")
 
-    pcoll = bpy.utils.previews.new()
-    pcoll.widget_list = ()
-    preview_collections["widgets"] = pcoll
-
-    bpy.types.WindowManager.widget_list = bpy.props.EnumProperty(
-        items=generate_previews(), name="Shape", description="Shape", update=preview_update
-    )
+    createPreviewCollection()
 
     def draw(self, context):
         layout = self.layout

--- a/panels.py
+++ b/panels.py
@@ -1,10 +1,8 @@
 import bpy
 import bpy.utils.previews
 from .functions import (
-    readWidgets,
     recurLayerCollection,
     preview_collections,
-    generate_previews,
     createPreviewCollection,
     get_preview_default,
 )
@@ -23,13 +21,6 @@ class BONEWIDGET_PT_bw_panel_main(BONEWIDGET_PT_bw_panel, bpy.types.Panel):
     bl_idname = 'BONEWIDGET_PT_bw_panel_main'
     bl_label = "Bone Widget"
 
-
-    itemsSort = []
-    for key, value in sorted(readWidgets().items()):
-        itemsSort.append((key, key, ""))
-
-    bpy.types.Scene.widget_list = bpy.props.EnumProperty(
-        items=itemsSort, name="Shape", description="Shape")
 
     createPreviewCollection()
 

--- a/panels.py
+++ b/panels.py
@@ -2,7 +2,6 @@ import bpy
 import bpy.utils.previews
 from .functions import (
     readWidgets,
-    getViewLayerCollection,
     recurLayerCollection,
     preview_collections,
     generate_previews,


### PR DESCRIPTION
So here is the first pass of the import and export functionality.
Try it out and let me know what you feel needs to be changed or added,
besides the users ability to properly handle name collisions.

I was thinking of maybe adding the choices: "overwrite, skip, ask" in the
file browser window as an option next.

Edit:
- I just added another big cleanup. I realized that I a lot of code was actually not needed anymore.
- I also changed the way the preview panel will decide which widget to display after deleting. Rather than just go back to the first one in the list each time, now it will display the widget that was next to it. Hopefully you agree with this change, as I found it more comfortable, especially when trying to delete a few test widgets.