### PR TITLE
Use Face Data toggle in the redo panel and other improvements

### DIFF
--- a/functions/jsonFunctions.py
+++ b/functions/jsonFunctions.py
@@ -7,6 +7,8 @@ from .. import __package__
 JSON_DEFAULT_WIDGETS = "widgets.json"
 JSON_USER_WIDGETS = "user_widgets.json"
 
+widget_data = {}
+
 
 def objectDataToDico(object):
     verts = []
@@ -29,13 +31,14 @@ def objectDataToDico(object):
     return(wgts)
 
 
-def readWidgets(file = ""):
+def readWidgets(filename = ""):
+    global widget_data
     wgts = {}
 
-    if not file:
+    if not filename:
         files = [JSON_DEFAULT_WIDGETS, JSON_USER_WIDGETS]
     else:
-        files = [file]
+        files = [filename]
 
     for file in files:
         jsonFile = os.path.join(os.path.dirname(os.path.dirname(__file__)), file)
@@ -43,8 +46,15 @@ def readWidgets(file = ""):
             f = open(jsonFile, 'r')
             wgts.update(json.load(f))
             f.close()
+            
+    if not filename: # if both files have been read
+        widget_data = wgts.copy()
 
     return (wgts)
+
+
+def getWidgetData(widget):
+    return widget_data[widget]
 
 
 def writeWidgets(wgts, file):

--- a/functions/mainFunctions.py
+++ b/functions/mainFunctions.py
@@ -98,7 +98,7 @@ def fromWidgetFindBone(widget):
     return matchBone
 
 
-def createWidget(bone, widget, relative, size, scale, slide, rotation, collection):
+def createWidget(bone, widget, relative, size, scale, slide, rotation, collection, show_wireframe):
     C = bpy.context
     D = bpy.data
 
@@ -151,7 +151,7 @@ def createWidget(bone, widget, relative, size, scale, slide, rotation, collectio
     layer.update()
 
     bone.custom_shape = newObject
-    bone.bone.show_wire = True
+    bone.bone.show_wire = show_wireframe
 
 
 def symmetrizeWidget(bone, collection):

--- a/functions/mainFunctions.py
+++ b/functions/mainFunctions.py
@@ -1,6 +1,5 @@
 import bpy
 import numpy
-from math import pi
 from mathutils import Matrix
 from .. import __package__
 

--- a/functions/mainFunctions.py
+++ b/functions/mainFunctions.py
@@ -97,7 +97,7 @@ def fromWidgetFindBone(widget):
     return matchBone
 
 
-def createWidget(bone, widget, relative, size, scale, slide, rotation, collection, show_wireframe):
+def createWidget(bone, widget, relative, size, scale, slide, rotation, collection, use_face_data):
     C = bpy.context
     D = bpy.data
 
@@ -120,9 +120,12 @@ def createWidget(bone, widget, relative, size, scale, slide, rotation, collectio
     else:
         boneLength = (1 / bone.bone.length)
 
+    # deal with face data
+    faces = widget['faces'] if use_face_data else []
+
     # add the verts
     newData.from_pydata(numpy.array(widget['vertices']) * [size[0] * scale[0] * boneLength, size[1] * scale[2]
-                        * boneLength, size[2] * scale[1] * boneLength], widget['edges'], widget['faces'])
+                        * boneLength, size[2] * scale[1] * boneLength], widget['edges'], faces)
 
     # Create tranform matrices (slide vector and rotation)
     widget_matrix = Matrix()
@@ -150,7 +153,7 @@ def createWidget(bone, widget, relative, size, scale, slide, rotation, collectio
     layer.update()
 
     bone.custom_shape = newObject
-    bone.bone.show_wire = show_wireframe
+    bone.bone.show_wire = True
 
 
 def symmetrizeWidget(bone, collection):

--- a/functions/mainFunctions.py
+++ b/functions/mainFunctions.py
@@ -258,12 +258,19 @@ def editWidget(active_bone):
     D = bpy.data
     widget = active_bone.custom_shape
 
+    collection = getViewLayerCollection(C, widget)
+    collection.hide_viewport = False
+
+    # hide all other objects in collection
+    for obj in collection.collection.all_objects:
+        if obj.name != widget.name:
+            obj.hide_set(True)
+        else:
+            obj.hide_set(False) # in case user manually hid it
+
     armature = active_bone.id_data
     bpy.ops.object.mode_set(mode='OBJECT')
     C.active_object.select_set(False)
-
-    collection = getViewLayerCollection(C, widget)
-    collection.hide_viewport = False
 
     if C.space_data.local_view:
         bpy.ops.view3d.localview()
@@ -272,6 +279,7 @@ def editWidget(active_bone):
     widget.select_set(True)
     bpy.context.view_layer.objects.active = widget
     bpy.ops.object.mode_set(mode='EDIT')
+    bpy.context.tool_settings.mesh_select_mode = (True, False, False) # enter vertex mode
 
 
 def returnToArmature(widget):
@@ -288,8 +296,14 @@ def returnToArmature(widget):
 
     collection = getViewLayerCollection(C, widget)
     collection.hide_viewport = True
+
+    # unhide all objects in the collection
+    for obj in collection.collection.all_objects:
+        obj.hide_set(False)
+    
     if C.space_data.local_view:
         bpy.ops.view3d.localview()
+    
     bpy.context.view_layer.objects.active = armature
     armature.select_set(True)
     bpy.ops.object.mode_set(mode='POSE')

--- a/functions/mainFunctions.py
+++ b/functions/mainFunctions.py
@@ -153,7 +153,7 @@ def createWidget(bone, widget, relative, size, scale, slide, rotation, collectio
     layer.update()
 
     bone.custom_shape = newObject
-    bone.bone.show_wire = True
+    bone.bone.show_wire = not use_face_data # show faces if use face data is enabled
 
 
 def symmetrizeWidget(bone, collection):

--- a/operators.py
+++ b/operators.py
@@ -50,10 +50,10 @@ class BONEWIDGET_OT_createWidget(bpy.types.Operator):
         description="Scale Widget to bone length"
     )
 
-    show_wireframe: BoolProperty(
-        name="Wireframe",
-        default=True,
-        description="Display widget as wireframe"
+    use_face_data: BoolProperty(
+        name="Use Face Data",
+        default=False,
+        description="When enabled this option will include widget face data from library if available"
     )
 
     advanced_options: BoolProperty(
@@ -108,7 +108,8 @@ class BONEWIDGET_OT_createWidget(bpy.types.Operator):
         row = col.row(align=True)
         row.prop(self, "relative_size")
         row = col.row(align=True)
-        row.prop(self, "show_wireframe")
+        if self.advanced_options:
+            row.prop(self, "use_face_data")
         row = col.row(align=True)
         row.prop(self, "global_size_advanced" if self.advanced_options else "global_size_simple", expand=False)
         row = col.row(align=True)
@@ -124,7 +125,7 @@ class BONEWIDGET_OT_createWidget(bpy.types.Operator):
         global_size = self.global_size_advanced if self.advanced_options else (self.global_size_simple,) * 3
         for bone in bpy.context.selected_pose_bones:
             createWidget(bone, widget_data, self.relative_size, global_size, [
-                         1, 1, 1], slide, self.rotation, getCollection(context), self.show_wireframe)
+                         1, 1, 1], slide, self.rotation, getCollection(context), self.use_face_data)
         return {'FINISHED'}
 
 

--- a/operators.py
+++ b/operators.py
@@ -50,6 +50,12 @@ class BONEWIDGET_OT_createWidget(bpy.types.Operator):
         description="Scale Widget to bone length"
     )
 
+    show_wireframe: BoolProperty(
+        name="Wireframe",
+        default=True,
+        description="Display widget as wireframe"
+    )
+
     advanced_options: BoolProperty(
         name="Advanced options",
         default=False,
@@ -102,6 +108,8 @@ class BONEWIDGET_OT_createWidget(bpy.types.Operator):
         row = col.row(align=True)
         row.prop(self, "relative_size")
         row = col.row(align=True)
+        row.prop(self, "show_wireframe")
+        row = col.row(align=True)
         row.prop(self, "global_size_advanced" if self.advanced_options else "global_size_simple", expand=False)
         row = col.row(align=True)
         row.prop(self, "slide_advanced" if self.advanced_options else "slide_simple", text="Slide")
@@ -116,7 +124,7 @@ class BONEWIDGET_OT_createWidget(bpy.types.Operator):
         global_size = self.global_size_advanced if self.advanced_options else (self.global_size_simple,) * 3
         for bone in bpy.context.selected_pose_bones:
             createWidget(bone, wgts[context.window_manager.widget_list], self.relative_size, global_size, [
-                         1, 1, 1], slide, self.rotation, getCollection(context))
+                         1, 1, 1], slide, self.rotation, getCollection(context), self.show_wireframe)
         return {'FINISHED'}
 
 

--- a/operators.py
+++ b/operators.py
@@ -9,7 +9,7 @@ from .functions import (
     editWidget,
     returnToArmature,
     addRemoveWidgets,
-    readWidgets,
+    getWidgetData,
     getCollection,
     getViewLayerCollection,
     recurLayerCollection,
@@ -119,11 +119,11 @@ class BONEWIDGET_OT_createWidget(bpy.types.Operator):
         row.prop(self, "advanced_options")
 
     def execute(self, context):
-        wgts = readWidgets()
+        widget_data = getWidgetData(context.window_manager.widget_list)
         slide = self.slide_advanced if self.advanced_options else (0.0, self.slide_simple, 0.0)
         global_size = self.global_size_advanced if self.advanced_options else (self.global_size_simple,) * 3
         for bone in bpy.context.selected_pose_bones:
-            createWidget(bone, wgts[context.window_manager.widget_list], self.relative_size, global_size, [
+            createWidget(bone, widget_data, self.relative_size, global_size, [
                          1, 1, 1], slide, self.rotation, getCollection(context), self.show_wireframe)
         return {'FINISHED'}
 


### PR DESCRIPTION
Here's what this pull request contains:

- ~~I hope I understood your thoughts regarding the ability to toggle wireframe in order to see widget faces in the redo panel. Feel free to change anything to make the wording better etc.~~

- While working on something else I noticed that every single time the redo panel is being edited, both json files will be read and loaded from disk. Click a checkbox, it's being read. Slide the widget 10 units, it's being read 10 times in a row. I have almost 100 widgets now, and I was noticing blender stuttering, each edit took half a second to update. Instead of re-loading json data, it's now stored in memory. I had to resort to using a global variable, as I couldn't think of another way to access the data needed. But it's a major performance boost when the json files contain a large amount of data.

Edit:
- Edit widget: Now when you press the edit widget button, all the other widgets you're not editing will have their eye icon toggled off. Also, I fixed another small issue as well. If the user has manually hidden some widgets in the widget collection, and you press edit, it would throw an error because it can't edit a hidden object. That's now taken care of. ALSO, if you were in, for example, face mode previously, and you would press edit widget, nothing would be selected. Each time I would press 'a' to find the widget I was supposed to edit, and manually go into vertex mode. I changed it so it will automatically go into vertex mode and the widget will now be selected properly.

- I added the Use Face Data functionality now. Feel free to update the description to something better if you want. You're better at that than I am. :) When you wrote the example description in the email you said: "if disabled it will force the widget to be in the wireframe view". Does that mean it should show the faces if you decide to include face data?