### PR TITLE
Custom Images and Import/Export improvements

### DIFF
--- a/functions/jsonFunctions.py
+++ b/functions/jsonFunctions.py
@@ -190,3 +190,28 @@ def importWidgetLibrary(filepath):
             pass
 
     return num_new_widgets, failed_imports
+
+
+def updateCustomImage(image_name):
+    current_widget = bpy.context.window_manager.widget_list
+    current_widget_data = getWidgetData(current_widget)
+
+    # swap out the image
+    current_widget_data['image'] = image_name
+
+     # update and write the new data
+    wgts = readWidgets(JSON_USER_WIDGETS)
+    if current_widget in wgts:
+        wgts[current_widget] = current_widget_data
+        writeWidgets(wgts, JSON_USER_WIDGETS)
+    else:
+        wgts = readWidgets(JSON_DEFAULT_WIDGETS)
+        wgts[current_widget] = current_widget_data
+        writeWidgets(wgts, JSON_DEFAULT_WIDGETS)
+
+    # update the preview panel
+    from .functions import createPreviewCollection
+    createPreviewCollection()
+    
+    # trigger an update and display original but updated widget
+    bpy.context.window_manager.widget_list = current_widget

--- a/functions/jsonFunctions.py
+++ b/functions/jsonFunctions.py
@@ -10,7 +10,7 @@ JSON_USER_WIDGETS = "user_widgets.json"
 widget_data = {}
 
 
-def objectDataToDico(object):
+def objectDataToDico(object, custom_image):
     verts = []
     depsgraph = bpy.context.evaluated_depsgraph_get()
     mesh = object.evaluated_get(depsgraph).to_mesh()
@@ -26,7 +26,9 @@ def objectDataToDico(object):
     for e in mesh.edges:
         edges.append(e.key)
 
-    wgts = {"vertices": verts, "edges": edges, "faces": polygons, "image": "user_defined.png"}
+    custom_image = custom_image if custom_image != "" else "user_defined.png"
+
+    wgts = {"vertices": verts, "edges": edges, "faces": polygons, "image": custom_image}
 
     return(wgts)
 
@@ -65,7 +67,7 @@ def writeWidgets(wgts, file):
     f.close()
 
 
-def addRemoveWidgets(context, addOrRemove, items, widgets, widget_name=""):
+def addRemoveWidgets(context, addOrRemove, items, widgets, widget_name="", custom_image=""):
     wgts = {}
 
     # file from where the widget should be read or written to
@@ -92,7 +94,7 @@ def addRemoveWidgets(context, addOrRemove, items, widgets, widget_name=""):
 
             if (ob_name) not in widget_items:
                 widget_items.append(ob_name)
-                wgts[ob_name] = objectDataToDico(ob)
+                wgts[ob_name] = objectDataToDico(ob, custom_image)
                 activeShape = ob_name
                 return_message = "Widget - " + ob_name + " has been added!"
 

--- a/functions/jsonFunctions.py
+++ b/functions/jsonFunctions.py
@@ -132,11 +132,30 @@ def exportWidgetLibrary(filepath):
     wgts = readWidgets(JSON_USER_WIDGETS)
 
     if wgts:
-        if not filepath.endswith(".bwl"):
-            filename += ".bwl"
-        f = open(os.path.join(filepath), 'w')
-        f.write(json.dumps(wgts))
-        f.close()
+        # variables needed for exporting widgets
+        dest_dir = os.path.dirname(filepath)
+        json_dir = os.path.dirname(os.path.dirname(__file__))
+        image_folder = 'custom_thumbnails'
+        custom_image_dir = os.path.abspath(os.path.join(os.path.dirname( __file__ ), '..', image_folder))
+        
+        filename = os.path.basename(filepath)
+        if not filename: filename = "widgetLibrary.zip"
+        elif not filename.endswith('.zip'): filename += ".zip"
+
+        # start the zipping process
+        from zipfile import ZipFile
+        with ZipFile(os.path.join(dest_dir, filename), "w") as zip:
+            # write the json file
+            file = os.path.join(json_dir, JSON_USER_WIDGETS)
+            arcname = os.path.basename(file)
+            zip.write(file, arcname=arcname)
+
+            # write the custom images if present
+            if os.path.exists(custom_image_dir):
+                from pathlib import Path
+                for filepath in Path(custom_image_dir).iterdir():
+                    arcname = os.path.join(image_folder, os.path.basename(filepath))
+                    zip.write(filepath, arcname=arcname)
 
     return len(wgts)
 

--- a/functions/mainFunctions.py
+++ b/functions/mainFunctions.py
@@ -115,17 +115,14 @@ def createWidget(bone, widget, relative, size, scale, slide, rotation, collectio
     # make the data name include the prefix
     newData = D.meshes.new(bw_widget_prefix + bone.name)
 
-    if relative is True:
-        boneLength = 1
-    else:
-        boneLength = (1.0 / bone.bone.length)
+    bone.use_custom_shape_bone_size = relative
 
     # deal with face data
     faces = widget['faces'] if use_face_data else []
 
     # add the verts
-    newData.from_pydata(numpy.array(widget['vertices']) * [size[0] * scale[0] * boneLength, size[1] * scale[2]
-                        * boneLength, size[2] * scale[1] * boneLength], widget['edges'], faces)
+    newData.from_pydata(numpy.array(widget['vertices']) * [size[0] * scale[0], size[1] * scale[2],
+                        size[2] * scale[1]], widget['edges'], faces)
 
     # Create tranform matrices (slide vector and rotation)
     widget_matrix = Matrix()

--- a/functions/mainFunctions.py
+++ b/functions/mainFunctions.py
@@ -467,3 +467,12 @@ def addObjectAsWidget(context, collection):
 
         #deselect original object
         widget_object.select_set(False)
+
+
+def advanced_options_toggled(self, context):
+    if self.advanced_options:
+        self.global_size_advanced = (self.global_size_simple,) * 3
+        self.slide_advanced[1] = self.slide_simple
+    else:
+        self.global_size_simple = self.global_size_advanced[1]
+        self.slide_simple = self.slide_advanced[1]

--- a/functions/mainFunctions.py
+++ b/functions/mainFunctions.py
@@ -118,7 +118,7 @@ def createWidget(bone, widget, relative, size, scale, slide, rotation, collectio
     if relative is True:
         boneLength = 1
     else:
-        boneLength = (1 / bone.bone.length)
+        boneLength = (1.0 / bone.bone.length)
 
     # deal with face data
     faces = widget['faces'] if use_face_data else []

--- a/functions/previewFunctions.py
+++ b/functions/previewFunctions.py
@@ -1,6 +1,6 @@
 import bpy
 import bpy.utils.previews
-from .jsonFunctions import readWidgets
+from .jsonFunctions import readWidgets, JSON_USER_WIDGETS
 import os
 from .. import __package__
 
@@ -92,6 +92,14 @@ def removeCustomImage(filename):
     destination_path = os.path.join(image_directory, filename)
     
     if os.path.isfile(destination_path):
+        # make sure the image is only used once - else stop
+        count = 0
+        for v in readWidgets(JSON_USER_WIDGETS).values():
+            if v.get("image") == filename:
+                count += 1
+            if count > 1:
+                return False
+            
         try:
             os.remove(destination_path)
             return True

--- a/functions/previewFunctions.py
+++ b/functions/previewFunctions.py
@@ -62,3 +62,16 @@ def preview_update(self, context):
 
 def get_preview_default():
     return bpy.context.preferences.addons[__package__].preferences.preview_default
+
+
+def removeCustomImage(filename):
+    image_directory = os.path.abspath(os.path.join(os.path.dirname( __file__ ), '..', 'custom_thumbnails'))
+    destination_path = os.path.join(image_directory, filename)
+    
+    if os.path.isfile(destination_path):
+        try:
+            os.remove(destination_path)
+            return True
+        except:
+            pass
+    return False

--- a/functions/previewFunctions.py
+++ b/functions/previewFunctions.py
@@ -32,6 +32,7 @@ def generate_previews():
     
     #directory = os.path.join(os.path.dirname(__file__), "thumbnails")
     directory = os.path.abspath(os.path.join(os.path.dirname( __file__ ), '..', 'thumbnails'))
+    custom_directory = os.path.abspath(os.path.join(os.path.dirname( __file__ ), '..', 'custom_thumbnails'))
 
     if directory and os.path.exists(directory):
         widget_data = {item[0]: item[1].get("image", "missing_image.png") for item in readWidgets().items()}
@@ -41,7 +42,11 @@ def generate_previews():
             image = widget_data.get(name, "")
             filepath = os.path.join(directory, image)
 
-            # make sure the image exist
+            # try in custom_thumbnails if above failed
+            if not os.path.exists(filepath):
+                filepath = os.path.join(custom_directory, image)
+
+            # if image still not found, let the user know
             if not os.path.exists(filepath):
                 filepath = os.path.join(directory, "missing_image.png")
 
@@ -51,7 +56,7 @@ def generate_previews():
             else:
                 thumb = pcoll[name]
             enum_items.append((name, name, "", thumb.icon_id, i))
-
+    
     pcoll.widget_list = enum_items
     return enum_items
 
@@ -62,6 +67,24 @@ def preview_update(self, context):
 
 def get_preview_default():
     return bpy.context.preferences.addons[__package__].preferences.preview_default
+
+
+def copyCustomImage(filepath, filename):
+    if os.path.exists(filepath):
+        image_directory = os.path.abspath(os.path.join(os.path.dirname( __file__ ), '..', 'custom_thumbnails'))
+        destination_path = os.path.join(image_directory, filename)
+
+        try:
+            # create custom thumbnail folder if not existing
+            if not os.path.exists(image_directory):
+                os.makedirs(image_directory)
+
+            import shutil
+            shutil.copyfile(filepath, destination_path)
+            return True
+        except:
+            pass
+    return False
 
 
 def removeCustomImage(filename):

--- a/menus.py
+++ b/menus.py
@@ -8,6 +8,8 @@ class BONEWIDGET_MT_bw_specials(Menu):
         layout.operator("bonewidget.add_widgets", icon="ADD", text="Add Widget to library")
         layout.operator("bonewidget.remove_widgets", icon="REMOVE",
                         text="Remove Widget from library")
+        layout.operator("bonewidget.add_custom_image", icon="FILE_IMAGE",
+                        text="Add Custom Image to Widget")
         layout.separator()
         layout.operator("bonewidget.import_library", icon="IMPORT", text="Import Widget Library")
         layout.operator("bonewidget.export_library", icon="EXPORT", text="Export Widget Library")

--- a/operators.py
+++ b/operators.py
@@ -332,7 +332,7 @@ class BONEWIDGET_OT_exportLibrary(bpy.types.Operator):
 
 
     filter_glob: StringProperty(
-        default='*.bwl',
+        default='*.zip',
         options={'HIDDEN'}
     )
     
@@ -352,7 +352,7 @@ class BONEWIDGET_OT_exportLibrary(bpy.types.Operator):
         return {'FINISHED'}
 
     def invoke(self, context, event):
-        self.filename = "widgetLibrary.bwl"
+        self.filename = "widgetLibrary.zip"
         context.window_manager.fileselect_add(self)
         return {'RUNNING_MODAL'}
 

--- a/operators.py
+++ b/operators.py
@@ -21,6 +21,7 @@ from .functions import (
     exportWidgetLibrary,
     createPreviewCollection,
     advanced_options_toggled,
+    removeCustomImage,
 )
 
 from bpy.props import FloatProperty, BoolProperty, FloatVectorProperty, StringProperty
@@ -273,6 +274,10 @@ class BONEWIDGET_OT_removeWidgets(bpy.types.Operator):
 
     def execute(self, context):
         objects = bpy.context.window_manager.widget_list
+
+        # try and remove the image - will abort if no custom image assigned or if missing
+        removeCustomImage(getWidgetData(objects).get("image"))
+        
         message_type, return_message = addRemoveWidgets(context, "remove", bpy.types.WindowManager.widget_list.keywords['items'], objects)
 
         if return_message:

--- a/operators.py
+++ b/operators.py
@@ -20,18 +20,10 @@ from .functions import (
     importWidgetLibrary,
     exportWidgetLibrary,
     createPreviewCollection,
+    advanced_options_toggled,
 )
 
 from bpy.props import FloatProperty, BoolProperty, FloatVectorProperty, StringProperty
-
-
-def advanced_options_toggled(self, context):
-    if self.advanced_options:
-        self.global_size_advanced = (self.global_size_simple,) * 3
-        self.slide_advanced[1] = self.slide_simple
-    else:
-        self.global_size_simple = self.global_size_advanced[1]
-        self.slide_simple = self.slide_advanced[1]
 
 
 class BONEWIDGET_OT_createWidget(bpy.types.Operator):


### PR DESCRIPTION
Now we can use custom images with our widgets. Can add when adding new widget
or later from the specials menu as you suggested.

We can now export custom images and the json file bundled into a zip file.

I also added the unzipping code. But I didn't have time to finish creating the operators
to handle the selection of zip file and the options for handling name collisions. It's almost
finished, but a bit of a mess right now. Just needs a bit of a cleanup and better layout.
It will be my next commit.