### PR TITLE
The last pieces to make the new import of library working

### DIFF
--- a/functions/mainFunctions.py
+++ b/functions/mainFunctions.py
@@ -196,7 +196,8 @@ def symmetrizeWidget(bone, collection):
 
         newObject.matrix_local = mirrorBone.bone.matrix_local
         newObject.scale = [mirrorBone.bone.length, mirrorBone.bone.length, mirrorBone.bone.length]
-
+        newObject.data.flip_normals()
+        
         layer = bpy.context.view_layer
         layer.update()
 

--- a/functions/mainFunctions.py
+++ b/functions/mainFunctions.py
@@ -203,6 +203,9 @@ def symmetrizeWidget(bone, collection):
         findMirrorObject(bone).custom_shape = newObject
         mirrorBone.bone.show_wire = True
 
+        if bpy.app.version >= (4,2,0):
+            mirrorBone.custom_shape_wire_width = bone.custom_shape_wire_width
+
     else:
         pass
 

--- a/functions/mainFunctions.py
+++ b/functions/mainFunctions.py
@@ -201,7 +201,7 @@ def symmetrizeWidget(bone, collection):
         layer.update()
 
         findMirrorObject(bone).custom_shape = newObject
-        mirrorBone.bone.show_wire = True
+        mirrorBone.bone.show_wire = bone.bone.show_wire
 
         if bpy.app.version >= (4,2,0):
             mirrorBone.custom_shape_wire_width = bone.custom_shape_wire_width

--- a/operators.py
+++ b/operators.py
@@ -262,7 +262,7 @@ class BONEWIDGET_OT_imageSelect(bpy.types.Operator):
 
     def execute(self, context):
         bpy.context.window_manager.prop_grp.custom_image_name = self.filename
-        bpy.context.window_manager.prop_grp.custom_image_data = (self.filepath, self.filename)
+        setattr(BONEWIDGET_OT_sharedPropertyGroup, "custom_image_data", (self.filepath, self.filename))
         context.area.tag_redraw()
         return {'FINISHED'}
 

--- a/operators.py
+++ b/operators.py
@@ -335,7 +335,10 @@ class BONEWIDGET_OT_addWidgets(bpy.types.Operator):
 
         if self.custom_image:
             row = layout.row()
-            row.prop(bpy.context.window_manager.prop_grp, "custom_image_name", text="", placeholder="Choose an image...", icon="FILE_IMAGE")
+            if bpy.app.version >= (4,1,0):
+                row.prop(bpy.context.window_manager.prop_grp, "custom_image_name", text="", placeholder="Choose an image...", icon="FILE_IMAGE")
+            else:
+                row.prop(bpy.context.window_manager.prop_grp, "custom_image_name", text="", icon="FILE_IMAGE")
             row.operator('bonewidget.image_select', icon='FILEBROWSER', text="")
 
     def invoke(self, context, event):


### PR DESCRIPTION
Finally, it's here!

Now the import of widget library from a zip file will work.
The user will be asked for default action when importing widgets when encountering duplicates: overwrite, skip, ask.

If the zip file contains custom images, only those that belong to the widgets to be imported will be moved to disk. Any widgets that were skipped with custom images will be ignored.

After import, the user will see a very basic popup (for now) with stats for how many widgets were imported, skipped, and failed.
When choosing the "ask" option, the user can choose what to do for each widget: overwrite local widget, skip the widget entirely (default) ,or rename widget to something else.