### PR TITLE
Fix for a NoneType error message

### DIFF
--- a/operators.py
+++ b/operators.py
@@ -153,7 +153,7 @@ class BONEWIDGET_OT_editWidget(bpy.types.Operator):
     @classmethod
     def poll(cls, context):
         return (context.object and context.object.type == 'ARMATURE' and context.object.mode == 'POSE'
-                and context.active_pose_bone.custom_shape is not None)
+                and context.active_pose_bone is not None and context.active_pose_bone.custom_shape is not None)
 
     def execute(self, context):
         active_bone = context.active_pose_bone


### PR DESCRIPTION
The poll method being called when there's no active bone selection causes an error message: 'NoneType' has no attribute 'custom_shape'