### PR TITLE
Add Release please for automated releases through pull requests

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,51 @@
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+name: release-please
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - uses: googleapis/release-please-action@v4
+        id: release
+        with:
+          # this assumes that you have created a personal access token
+          # (PAT) and configured it as a GitHub action secret named
+          # `MY_RELEASE_PLEASE_TOKEN` (this secret name is not important).
+          token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
+          # this is a built-in strategy in release-please, see "Action Inputs"
+          # for more options
+          release-type: simple
+      - name: Create artifacts directory
+        if: ${{ steps.release.outputs.release_created }}
+        run: mkdir -p artifacts
+      - name: Create boneWidget subdirectory
+        if: ${{ steps.release.outputs.release_created }}
+        run: mkdir -p boneWidget
+      - name: Copy repository contents to boneWidget subdirectory
+        if: ${{ steps.release.outputs.release_created }}
+        run: |
+          # Copy all files except .git directory and the boneWidget directory itself
+          rsync -av --exclude='.git' --exclude='boneWidget' . boneWidget/
+      - name: Create zip archive
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          VERSION: ${{ steps.release.outputs.tag_name }}
+        run: |
+          zip -r "artifacts/boneWidget-$VERSION.zip" boneWidget/
+      - name: Upload Release Artifact
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
+          VERSION: ${{ steps.release.outputs.tag_name }}
+        run: gh release upload ${{ steps.release.outputs.tag_name }} ./artifacts/boneWidget-${{ steps.release.outputs.tag_name }}.zip

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -37,6 +37,15 @@ jobs:
         run: |
           # Copy all files except .git directory and the boneWidget directory itself
           rsync -av --exclude='.git' --exclude='boneWidget' . boneWidget/
+      - name: Update __init__.py with new version
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          VERSION: ${{ steps.release.outputs.tag_name }}
+          MAJOR: $(echo "$VERSION" | cut -d'.' -f1)
+          MINOR: $(echo "$VERSION" | cut -d'.' -f2)
+          PATCH: $(echo "$VERSION" | cut -d'.' -f3)
+        run: |
+          sed -i "s/^    \"version\":.*/    \"version\": (${MAJOR}, ${MINOR}, ${PATCH})/" boneWidget/__init__.py
       - name: Create zip archive
         if: ${{ steps.release.outputs.release_created }}
         env:


### PR DESCRIPTION
It looks like you are probably using a manual release workflow for this add-on. I thought I might be able to help you automate some of it and hopefully take some burden off cutting release notes as well. Happy to answer questions if you have any or if you decide that this is all too fiddly and you don't want to use it, my feelings won't be hurt. 

## What does this change do?

This creates a GitHub action workflow that will do a few things:

- When any changes are merged into the `master` branch, the workflow will see if there's a pull request for the next release and create one if it doesn't exist.
- It will look at the commit messages for anything that's being merged and if they follow [The Conventional Commits format](https://www.conventionalcommits.org/en/v1.0.0/) then they will be added to the description of the Pull Request as part of the draft change release notes. Examples are `fix: update YouTube links` or `feat: add faces to widgets`
- When you merge that PR it will automatically create a new Release tag and Zip file for the repo so people can download the new release.

## Examples
I made some examples so you could see how it works in action. I created a `boneWidgetTest` repo in my GitHub [here](https://github.com/gekitsuu/boneWidgetTest)

[Here is the initial PR](https://github.com/gekitsuu/boneWidgetTest/pull/1) where I added Release Please to the repo and you can see that from [the commit ](https://github.com/gekitsuu/boneWidgetTest/commit/d6b60192edb8b2ea7d04e60ff8c9e1098a2aed0d) it picked up the comment `feat: Testing the addition of "release-please" GitHub action` and added it to [the Release notes](https://github.com/gekitsuu/boneWidgetTest/releases/tag/v1.0.0).

Then I wanted to test how it handles existing releases to make sure it'd handle your existing release versions. I manually created a release tag and set it to [v2.0.1](https://github.com/gekitsuu/boneWidgetTest/releases/tag/v2.0.1) then I pushed another change adding a CONTRIBUTORS.md file (going to give that to you in a separate PR) and you can see that it marked the next release as 2.1.0 automatically because I was adding a new "feature"

## If you want to use this what you'll need to do
- Create a GitHub API token for the `waylow/boneWidget` repo that has permissions to do the following in the boneWidget repository <img width="419" height="273" alt="image" src="https://github.com/user-attachments/assets/4d2c82c0-193c-4809-83c7-e022b776e1e4" />
- Save the token as a GitHub Actions Repository secret named `MY_RELEASE_PLEASE_TOKEN` 
 - Merge in this PR
 
## What does your workflow look like going forward?

- Start using the "Conventional Commits" commit message prefixes `fix:`, `feat:`, or and optionally add a footer of  `BREAKING CHANGE:<Reason>` to the bottom of your commit.
- Develop changes as you have been by working in the `develop` branch and merging them in to `master` when you're ready to. Merging them into `master` will get them staged in the release PR that the workflow creates.
- When you're ready to cut a new release, simply merge the PR and the workflow will do the rest. If you want to modify the release notes you can edit the PR description before you merge.

## How much will this cost?

You're releasing infrequently enough that you should never come close to leaving [the free tier for GitHub actions](https://docs.github.com/en/billing/concepts/product-billing/github-actions)

 ## How do you disable this later?
 
 - Delete the `release-please.yml` file or the `.github` directory entirely.
 - Delete the GitHub Secret that you created
 - Delete the GitHub token you created