### PR TITLE
Add CloudRig multi-widget support via enum switching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 custom_thumbnails/
 user_widgets.json
 custom_color_sets.json
+test/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "DockerRun.DisableDockerrc": true
+}

--- a/functions/main_functions.py
+++ b/functions/main_functions.py
@@ -869,6 +869,11 @@ def update_cloudrig_widget(bone, param_value, widget_obj, component_type=None):
             shape_param.use_pointer = True
         if hasattr(shape_param, 'custom_shape'):
             shape_param.custom_shape = widget_obj
+            
+            # 刷新 CloudRig GPU 预览
+            if hasattr(component, 'overlay_is_dirty'):
+                component.overlay_is_dirty = True
+            
             return True
     except Exception as e:
         print(f"Bone Widget: Failed to update CloudRig: {e}")

--- a/functions/main_functions.py
+++ b/functions/main_functions.py
@@ -641,13 +641,135 @@ def get_preferences(context):
 
 
 # ========================================================================
-# CloudRig 支持函数（简化版本 - 仅 Spine: Cartoon）
+# CloudRig 支持函数
 # ========================================================================
+
+def get_cloudrig_param_mappings():
+    """
+    获取所有 CloudRig 组件的参数映射。
+    
+    Returns:
+        dict: 组件类型到参数映射的字典
+    """
+    return {
+        # 脊柱组件
+        'Spine: Cartoon': {
+            'SHAPE_IK': ('spine_toon', 'shape_ik'),
+            'SHAPE_IK_SECONDARY': ('spine_toon', 'shape_ik_secondary'),
+            'SHAPE_TORSO': ('spine_toon', 'shape_torso'),
+            'SHAPE_FK': ('fk_chain', 'shape_fk'),
+            'SHAPE_FK_ROOT': ('fk_chain', 'shape_fk_root'),
+        },
+        'Spine: IK/FK': {
+            'SHAPE_HIP': ('spine', 'shape_hip'),
+            'SHAPE_CHEST': ('spine', 'shape_chest'),
+            'SHAPE_TORSO': ('spine', 'shape_torso'),
+            'SHAPE_IK': ('spine', 'shape_ik'),
+        },
+        'Spine: Squashy': {
+            'SHAPE_FK': ('fk_chain', 'shape_fk'),
+            'SHAPE_FK_ROOT': ('fk_chain', 'shape_fk_root'),
+        },
+        # 肢体组件
+        'Limb: Biped Leg': {
+            'LEG_STRETCH': ('chain', 'shape_stretch'),
+            'LEG_STRETCH_ENDS': ('chain', 'shape_stretch_ends'),
+            'LEG_FK': ('fk_chain', 'shape_fk'),
+            'LEG_FK_ROOT': ('fk_chain', 'shape_fk_root'),
+            'LEG_IK_MASTER': ('ik_chain', 'shape_ik_master'),
+            'LEG_IK_FIRST': ('ik_chain', 'shape_ik_first'),
+            'LEG_IK_POLE': ('ik_chain', 'shape_pole'),
+            'LEG_FOOT_ROLL': ('leg', 'shape_footroll'),
+            'LEG_FOREFOOT': ('leg', 'shape_forefoot'),
+        },
+        'Limb: Generic': {
+            'LIMB_STRETCH': ('chain', 'shape_stretch'),
+            'LIMB_STRETCH_ENDS': ('chain', 'shape_stretch_ends'),
+            'LIMB_FK': ('fk_chain', 'shape_fk'),
+            'LIMB_FK_ROOT': ('fk_chain', 'shape_fk_root'),
+            'LIMB_IK_MASTER': ('ik_chain', 'shape_ik_master'),
+            'LIMB_IK_FIRST': ('ik_chain', 'shape_ik_first'),
+            'LIMB_IK_POLE': ('ik_chain', 'shape_pole'),
+            'LIMB_RUBBERHOSE': ('limb', 'shape_rubberhose'),
+        },
+        # 链式组件
+        'Chain: FK': {
+            'FK_SHAPE': ('fk_chain', 'shape_fk'),
+            'FK_ROOT_SHAPE': ('fk_chain', 'shape_fk_root'),
+        },
+        'Chain: IK': {
+            'IK_MASTER': ('ik_chain', 'shape_ik_master'),
+            'IK_FIRST': ('ik_chain', 'shape_ik_first'),
+            'IK_POLE': ('ik_chain', 'shape_pole'),
+        },
+        'Chain: Toon': {
+            'CHAIN_STRETCH': ('chain', 'shape_stretch'),
+            'CHAIN_STRETCH_ENDS': ('chain', 'shape_stretch_ends'),
+            'CHAIN_DEF_CONTROL': ('chain', 'shape_def_control'),
+        },
+        'Chain: Sphere': {
+            'SPHERE_CONTROL': ('chain_sphere', 'shape_sphere_control'),
+        },
+        'Chain: Finger': {
+            'FINGER_FK': ('fk_chain', 'shape_fk'),
+            'FINGER_FK_ROOT': ('fk_chain', 'shape_fk_root'),
+            'FINGER_IK_MASTER': ('ik_chain', 'shape_ik_master'),
+            'FINGER_IK_FIRST': ('ik_chain', 'shape_ik_first'),
+            'FINGER_IK_POLE': ('ik_chain', 'shape_pole'),
+        },
+        'Chain: Face Grid': {
+            'FACE_INTERSECTION': ('face_chain', 'shape_intersection'),
+        },
+        'Chain: Eyelid': {
+            'EYELID_FK': ('fk_chain', 'shape_fk'),
+            'EYELID_FK_ROOT': ('fk_chain', 'shape_fk_root'),
+        },
+        'Chain: Physics': {
+            'PHYSICS_FK': ('fk_chain', 'shape_fk'),
+            'PHYSICS_FK_ROOT': ('fk_chain', 'shape_fk_root'),
+        },
+        # 其他组件
+        'Aim': {
+            'AIM_TARGET': ('aim', 'shape_target'),
+            'AIM_EYE': ('aim', 'shape_eye'),
+            'AIM_ROOT': ('aim', 'shape_root'),
+            'AIM_HIGHLIGHT': ('aim', 'shape_highlight'),
+            'AIM_MASTER': ('aim', 'shape_master'),
+        },
+        'Single Control': {
+            'CONTROL_SHAPE': ('copy', 'shape_control'),
+            'CONTROL_PIVOT': ('copy', 'shape_pivot'),
+        },
+        'Shoulder Bone': {
+            'SHOULDER_SHAPE': ('shoulder', 'shape_shoulder'),
+        },
+        'Feather': {
+            'FEATHER_SHAPE': ('feather', 'shape_feather'),
+        },
+        'Lattice': {
+            'LATTICE_ROOT': ('lattice', 'shape_root'),
+            'LATTICE_SHAPE': ('lattice', 'shape_lattice'),
+        },
+        # 曲线组件
+        'Curve: With Hooks': {
+            'CURVE_ROOT': ('curve', 'shape_root'),
+            'CURVE_POINT': ('curve', 'shape_point'),
+            'CURVE_HANDLE': ('curve', 'shape_handle'),
+            'CURVE_BEZIER_CENTER': ('curve', 'shape_bezier_center'),
+            'CURVE_BEZIER': ('curve', 'shape_bezier'),
+            'CURVE_SPLINE_ROOT': ('curve', 'shape_spline_root'),
+            'CURVE_RADIUS': ('curve', 'shape_radius'),
+        },
+        'Curve: Spline IK': {
+            'SPLINE_FK': ('spline_ik', 'shape_fk'),
+        },
+    }
+
 
 def update_cloudrig_widget(bone, param_value, widget_obj, component_type=None):
     """
     更新 CloudRig 组件的形状参数引用。
-    支持 Spine: Cartoon 和 Limb: Biped Leg 组件。
+    支持所有 CloudRig 组件。
     
     Args:
         bone: PoseBone
@@ -674,26 +796,8 @@ def update_cloudrig_widget(bone, param_value, widget_obj, component_type=None):
     
     params = component.params
     
-    # 根据组件类型选择参数映射（使用原始字符串作为 key）
-    param_mappings = {
-        'Spine: Cartoon': {
-            'SHAPE_IK': ('spine_toon', 'shape_ik'),
-            'SHAPE_IK_SECONDARY': ('spine_toon', 'shape_ik_secondary'),
-            'SHAPE_TORSO': ('spine_toon', 'shape_torso'),
-            'SHAPE_FK': ('fk_chain', 'shape_fk'),
-            'SHAPE_FK_ROOT': ('fk_chain', 'shape_fk_root'),
-        },
-        'Limb: Biped Leg': {
-            'LEG_STRETCH': ('chain', 'shape_stretch'),
-            'LEG_STRETCH_ENDS': ('chain', 'shape_stretch_ends'),
-            'LEG_FK': ('fk_chain', 'shape_fk'),
-            'LEG_FK_ROOT': ('fk_chain', 'shape_fk_root'),
-            'LEG_IK_MASTER': ('ik_chain', 'shape_ik_master'),
-            'LEG_IK_FIRST': ('ik_chain', 'shape_ik_first'),
-            'LEG_IK_POLE': ('ik_chain', 'shape_pole'),
-            'LEG_FOOT_ROLL': ('leg', 'shape_footroll'),
-        },
-    }
+    # 获取参数映射
+    param_mappings = get_cloudrig_param_mappings()
     
     if component_type not in param_mappings:
         return False
@@ -787,26 +891,8 @@ def get_cloudrig_widget(bone, param_value, component_type=None):
     
     params = component.params
     
-    # 根据组件类型选择参数映射（使用原始字符串作为 key）
-    param_mappings = {
-        'Spine: Cartoon': {
-            'SHAPE_IK': ('spine_toon', 'shape_ik'),
-            'SHAPE_IK_SECONDARY': ('spine_toon', 'shape_ik_secondary'),
-            'SHAPE_TORSO': ('spine_toon', 'shape_torso'),
-            'SHAPE_FK': ('fk_chain', 'shape_fk'),
-            'SHAPE_FK_ROOT': ('fk_chain', 'shape_fk_root'),
-        },
-        'Limb: Biped Leg': {
-            'LEG_STRETCH': ('leg', 'stretch_shape'),
-            'LEG_STRETCH_ENDS': ('leg', 'stretch_ends_shape'),
-            'LEG_FK': ('leg', 'fk_shape'),
-            'LEG_FK_ROOT': ('leg', 'fk_root_shape'),
-            'LEG_IK_MASTER': ('leg', 'ik_master_shape'),
-            'LEG_IK_FIRST': ('leg', 'first_ik_shape'),
-            'LEG_IK_POLE': ('leg', 'ik_pole_shape'),
-            'LEG_FOOT_ROLL': ('leg', 'foot_roll_shape'),
-        },
-    }
+    # 获取参数映射
+    param_mappings = get_cloudrig_param_mappings()
     
     if component_type not in param_mappings:
         return None
@@ -837,14 +923,14 @@ def get_cloudrig_widget(bone, param_value, component_type=None):
 # 保留旧函数名以保持兼容性
 def get_cloudrig_spine_toon_widget(bone, param_value):
     """旧函数名，保留兼容性"""
-    return get_cloudrig_widget(bone, param_value, 'SPINE_TOON')
+    return get_cloudrig_widget(bone, param_value, 'Spine: Cartoon')
 
 
 def find_bone_from_cloudrig_widget(widget):
     """
     通过 CloudRig 控件查找对应的骨骼。
     检查所有骨骼的 CloudRig 组件参数中是否引用了该控件。
-    支持 Spine: Cartoon 和 Limb: Biped Leg 组件。
+    支持所有 CloudRig 组件。
     
     Args:
         widget: 控件对象
@@ -855,24 +941,14 @@ def find_bone_from_cloudrig_widget(widget):
     if widget is None:
         return None
     
-    # 所有支持的参数路径
-    all_param_paths = [
-        # Spine: Cartoon
-        ('spine_toon', 'shape_ik'),
-        ('spine_toon', 'shape_ik_secondary'),
-        ('spine_toon', 'shape_torso'),
-        ('fk_chain', 'shape_fk'),
-        ('fk_chain', 'shape_fk_root'),
-        # Limb: Biped Leg
-        ('chain', 'shape_stretch'),
-        ('chain', 'shape_stretch_ends'),
-        ('fk_chain', 'shape_fk'),
-        ('fk_chain', 'shape_fk_root'),
-        ('ik_chain', 'shape_ik_master'),
-        ('ik_chain', 'shape_ik_first'),
-        ('ik_chain', 'shape_pole'),
-        ('leg', 'shape_footroll'),
-    ]
+    # 所有支持的参数路径（从参数映射中提取）
+    param_mappings = get_cloudrig_param_mappings()
+    all_param_paths = set()
+    for mapping in param_mappings.values():
+        for namespace, param_name in mapping.values():
+            all_param_paths.add((namespace, param_name))
+    
+    all_param_paths = list(all_param_paths)
     
     for ob in bpy.context.scene.objects:
         if ob.type == "ARMATURE":

--- a/functions/main_functions.py
+++ b/functions/main_functions.py
@@ -32,6 +32,50 @@ def get_collection(context):
         return collection
 
 
+def get_cloudrig_widget_collection(context):
+    """
+    获取 CloudRig 的 widget collection。
+    如果当前选中的骨骼属于 CloudRig，则返回 CloudRig 的 widget collection。
+    
+    Args:
+        context: Blender 上下文
+    
+    Returns:
+        Collection: CloudRig 的 widget collection，如果没有则返回 None
+    """
+    active_obj = context.active_object
+    if not active_obj or active_obj.type != 'ARMATURE':
+        return None
+    
+    # 检查是否是 CloudRig 骨骼
+    if hasattr(active_obj, 'cloudrig') and active_obj.cloudrig:
+        generator = active_obj.cloudrig.generator
+        if generator and hasattr(generator, 'widget_collection'):
+            return generator.widget_collection
+    
+    return None
+
+
+def get_widget_collection(context):
+    """
+    获取用于放置 widget 的集合。
+    优先使用 CloudRig 的 widget collection，否则使用默认的 Bone Widget collection。
+    
+    Args:
+        context: Blender 上下文
+    
+    Returns:
+        Collection: 用于放置 widget 的集合
+    """
+    # 首先尝试获取 CloudRig 的 widget collection
+    cloudrig_collection = get_cloudrig_widget_collection(context)
+    if cloudrig_collection:
+        return cloudrig_collection
+    
+    # 否则使用默认的 Bone Widget collection
+    return get_collection(context)
+
+
 def recursive_layer_collection(layer_collection, collection_name):
     found = None
     if (layer_collection.name == collection_name):

--- a/functions/main_functions.py
+++ b/functions/main_functions.py
@@ -103,18 +103,25 @@ def from_widget_find_bone(widget):
     return match_bone
 
 
-def create_widget(bone, widget, relative, size, slide, rotation, collection, use_face_data, wireframe_width):
+def create_widget(bone, widget, relative, size, slide, rotation, collection, use_face_data, wireframe_width, cloudrig_param='NONE'):
     if not get_preferences(bpy.context).use_rigify_defaults:
         bw_widget_prefix = get_preferences(bpy.context).widget_prefix
     else:
         bw_widget_prefix = "WGT-" + bpy.context.active_object.name + "_"
 
     matrix_bone = bone
+    
+    # CloudRig 参数后缀
+    param_suffix = ""
+    if cloudrig_param != 'NONE':
+        param_suffix = "_" + cloudrig_param.replace("SHAPE_", "")
+    
+    widget_name = bw_widget_prefix + bone.name + param_suffix
 
-    # delete the existing shape
-    if bone.custom_shape:
-        bpy.data.objects.remove(
-            bpy.data.objects[bone.custom_shape.name], do_unlink=True)
+    # delete the existing shape with the same name
+    existing_obj = bpy.data.objects.get(widget_name)
+    if existing_obj:
+        bpy.data.objects.remove(existing_obj, do_unlink=True)
 
     # make the data name include the prefix
     new_data = bpy.data.meshes.new(bw_widget_prefix + bone.name)
@@ -148,10 +155,10 @@ def create_widget(bone, widget, relative, size, slide, rotation, collection, use
 
     new_data.update(calc_edges=True)
 
-    new_object = bpy.data.objects.new(bw_widget_prefix + bone.name, new_data)
+    new_object = bpy.data.objects.new(widget_name, new_data)
 
     new_object.data = new_data
-    new_object.name = bw_widget_prefix + bone.name
+    new_object.name = widget_name
     collection.objects.link(new_object)
 
     new_object.matrix_world = bpy.context.active_object.matrix_world @ matrix_bone.bone.matrix_local
@@ -160,12 +167,16 @@ def create_widget(bone, widget, relative, size, slide, rotation, collection, use
     layer = bpy.context.view_layer
     layer.update()
 
-    bone.custom_shape = new_object
-    # show faces if use face data is enabled
-    bone.bone.show_wire = not use_face_data
+    # CloudRig 模式：不设置骨骼的 custom_shape，只返回对象
+    if cloudrig_param == 'NONE':
+        bone.custom_shape = new_object
+        # show faces if use face data is enabled
+        bone.bone.show_wire = not use_face_data
 
-    if bpy.app.version >= (4, 2, 0):
-        bone.custom_shape_wire_width = wireframe_width
+        if bpy.app.version >= (4, 2, 0):
+            bone.custom_shape_wire_width = wireframe_width
+    
+    return new_object
 
 
 def symmetrize_widget(bone, collection):
@@ -272,8 +283,12 @@ def delete_unused_widgets():
     return
 
 
-def edit_widget(active_bone):
-    widget = active_bone.custom_shape
+def edit_widget(active_bone, widget=None):
+    if widget is None:
+        widget = active_bone.custom_shape
+
+    if widget is None:
+        raise KeyError("Bone has no custom shape widget")
 
     collection = get_view_layer_collection(bpy.context, widget)
     collection.hide_viewport = False
@@ -300,8 +315,18 @@ def edit_widget(active_bone):
         True, False, False)  # enter vertex mode
 
 
-def return_to_armature(widget):
-    bone = from_widget_find_bone(widget)
+def return_to_armature(widget, bone=None):
+    # 如果没有提供 bone，尝试查找
+    if bone is None:
+        bone = from_widget_find_bone(widget)
+    
+    # 还是没找到，尝试 CloudRig 查找
+    if bone is None:
+        bone = find_bone_from_cloudrig_widget(widget)
+    
+    if bone is None:
+        return False
+    
     armature = bone.id_data
 
     if bpy.context.active_object.mode == 'EDIT':
@@ -325,6 +350,7 @@ def return_to_armature(widget):
     if bpy.app.version < (5, 0, 0):
         armature.data.bones[bone.name].select = True
     armature.data.bones.active = armature.data.bones[bone.name]
+    return True
 
 
 def find_mirror_object(object):
@@ -612,3 +638,292 @@ def live_update_toggle(self, context):
 
 def get_preferences(context):
     return context.preferences.addons[__package__].preferences
+
+
+# ========================================================================
+# CloudRig 支持函数（简化版本 - 仅 Spine: Cartoon）
+# ========================================================================
+
+def update_cloudrig_widget(bone, param_value, widget_obj, component_type=None):
+    """
+    更新 CloudRig 组件的形状参数引用。
+    支持 Spine: Cartoon 和 Limb: Biped Leg 组件。
+    
+    Args:
+        bone: PoseBone
+        param_value: 参数值
+        widget_obj: 控件对象
+        component_type: 可选，强制指定组件类型
+    
+    Returns:
+        bool: 是否成功
+    """
+    if not hasattr(bone, 'cloudrig_component'):
+        return False
+    
+    component = bone.cloudrig_component
+    if not component or not hasattr(component, 'params'):
+        return False
+    
+    # 自动检测组件类型
+    if component_type is None:
+        component_type = get_cloudrig_component_type(bone)
+    
+    if component_type is None:
+        return False
+    
+    params = component.params
+    
+    # 根据组件类型选择参数映射（使用原始字符串作为 key）
+    param_mappings = {
+        'Spine: Cartoon': {
+            'SHAPE_IK': ('spine_toon', 'shape_ik'),
+            'SHAPE_IK_SECONDARY': ('spine_toon', 'shape_ik_secondary'),
+            'SHAPE_TORSO': ('spine_toon', 'shape_torso'),
+            'SHAPE_FK': ('fk_chain', 'shape_fk'),
+            'SHAPE_FK_ROOT': ('fk_chain', 'shape_fk_root'),
+        },
+        'Limb: Biped Leg': {
+            'LEG_STRETCH': ('chain', 'shape_stretch'),
+            'LEG_STRETCH_ENDS': ('chain', 'shape_stretch_ends'),
+            'LEG_FK': ('fk_chain', 'shape_fk'),
+            'LEG_FK_ROOT': ('fk_chain', 'shape_fk_root'),
+            'LEG_IK_MASTER': ('ik_chain', 'shape_ik_master'),
+            'LEG_IK_FIRST': ('ik_chain', 'shape_ik_first'),
+            'LEG_IK_POLE': ('ik_chain', 'shape_pole'),
+            'LEG_FOOT_ROLL': ('leg', 'shape_footroll'),
+        },
+    }
+    
+    if component_type not in param_mappings:
+        return False
+    
+    mapping = param_mappings[component_type]
+    
+    if param_value not in mapping:
+        return False
+    
+    namespace, param_name = mapping[param_value]
+    
+    if not hasattr(params, namespace):
+        return False
+    
+    param_group = getattr(params, namespace)
+    
+    if not hasattr(param_group, param_name):
+        return False
+    
+    shape_param = getattr(param_group, param_name)
+    
+    # 设置 use_pointer 并更新 custom_shape
+    try:
+        if hasattr(shape_param, 'use_pointer'):
+            shape_param.use_pointer = True
+        if hasattr(shape_param, 'custom_shape'):
+            shape_param.custom_shape = widget_obj
+            return True
+    except Exception as e:
+        print(f"Bone Widget: Failed to update CloudRig: {e}")
+    
+    return False
+
+
+# 保留旧函数名以保持兼容性
+def update_cloudrig_spine_toon(bone, param_value, widget_obj):
+    """旧函数名，保留兼容性"""
+    return update_cloudrig_widget(bone, param_value, widget_obj, 'Spine: Cartoon')
+
+
+def get_cloudrig_component_type(bone):
+    """
+    检测骨骼的 CloudRig 组件类型。
+    
+    Args:
+        bone: PoseBone
+    
+    Returns:
+        str: 组件类型原始字符串（如 'Spine: Cartoon', 'Limb: Biped Leg'），或 None
+    """
+    if not hasattr(bone, 'cloudrig_component'):
+        return None
+    
+    component = bone.cloudrig_component
+    if not component:
+        return None
+    
+    # 直接返回组件类型的显示名称
+    if hasattr(component, 'component_type'):
+        return component.component_type
+    
+    return None
+
+
+def get_cloudrig_widget(bone, param_value, component_type=None):
+    """
+    获取 CloudRig 组件参数引用的控件对象。
+    支持 Spine: Cartoon 和 Limb: Biped Leg 组件。
+    
+    Args:
+        bone: PoseBone
+        param_value: 参数值（如 'SHAPE_IK', 'LEG_FK' 等）
+        component_type: 可选，强制指定组件类型原始字符串
+    
+    Returns:
+        Object: 控件对象，如果找不到则返回 None
+    """
+    if not hasattr(bone, 'cloudrig_component'):
+        return None
+    
+    component = bone.cloudrig_component
+    if not component or not hasattr(component, 'params'):
+        return None
+    
+    # 自动检测组件类型
+    if component_type is None:
+        component_type = get_cloudrig_component_type(bone)
+    
+    if component_type is None:
+        return None
+    
+    params = component.params
+    
+    # 根据组件类型选择参数映射（使用原始字符串作为 key）
+    param_mappings = {
+        'Spine: Cartoon': {
+            'SHAPE_IK': ('spine_toon', 'shape_ik'),
+            'SHAPE_IK_SECONDARY': ('spine_toon', 'shape_ik_secondary'),
+            'SHAPE_TORSO': ('spine_toon', 'shape_torso'),
+            'SHAPE_FK': ('fk_chain', 'shape_fk'),
+            'SHAPE_FK_ROOT': ('fk_chain', 'shape_fk_root'),
+        },
+        'Limb: Biped Leg': {
+            'LEG_STRETCH': ('leg', 'stretch_shape'),
+            'LEG_STRETCH_ENDS': ('leg', 'stretch_ends_shape'),
+            'LEG_FK': ('leg', 'fk_shape'),
+            'LEG_FK_ROOT': ('leg', 'fk_root_shape'),
+            'LEG_IK_MASTER': ('leg', 'ik_master_shape'),
+            'LEG_IK_FIRST': ('leg', 'first_ik_shape'),
+            'LEG_IK_POLE': ('leg', 'ik_pole_shape'),
+            'LEG_FOOT_ROLL': ('leg', 'foot_roll_shape'),
+        },
+    }
+    
+    if component_type not in param_mappings:
+        return None
+    
+    mapping = param_mappings[component_type]
+    
+    if param_value not in mapping:
+        return None
+    
+    namespace, param_name = mapping[param_value]
+    
+    if not hasattr(params, namespace):
+        return None
+    
+    param_group = getattr(params, namespace)
+    
+    if not hasattr(param_group, param_name):
+        return None
+    
+    shape_param = getattr(param_group, param_name)
+    
+    if hasattr(shape_param, 'custom_shape'):
+        return shape_param.custom_shape
+    
+    return None
+
+
+# 保留旧函数名以保持兼容性
+def get_cloudrig_spine_toon_widget(bone, param_value):
+    """旧函数名，保留兼容性"""
+    return get_cloudrig_widget(bone, param_value, 'SPINE_TOON')
+
+
+def find_bone_from_cloudrig_widget(widget):
+    """
+    通过 CloudRig 控件查找对应的骨骼。
+    检查所有骨骼的 CloudRig 组件参数中是否引用了该控件。
+    支持 Spine: Cartoon 和 Limb: Biped Leg 组件。
+    
+    Args:
+        widget: 控件对象
+    
+    Returns:
+        PoseBone: 找到的骨骼，没找到返回 None
+    """
+    if widget is None:
+        return None
+    
+    # 所有支持的参数路径
+    all_param_paths = [
+        # Spine: Cartoon
+        ('spine_toon', 'shape_ik'),
+        ('spine_toon', 'shape_ik_secondary'),
+        ('spine_toon', 'shape_torso'),
+        ('fk_chain', 'shape_fk'),
+        ('fk_chain', 'shape_fk_root'),
+        # Limb: Biped Leg
+        ('chain', 'shape_stretch'),
+        ('chain', 'shape_stretch_ends'),
+        ('fk_chain', 'shape_fk'),
+        ('fk_chain', 'shape_fk_root'),
+        ('ik_chain', 'shape_ik_master'),
+        ('ik_chain', 'shape_ik_first'),
+        ('ik_chain', 'shape_pole'),
+        ('leg', 'shape_footroll'),
+    ]
+    
+    for ob in bpy.context.scene.objects:
+        if ob.type == "ARMATURE":
+            for bone in ob.pose.bones:
+                if not hasattr(bone, 'cloudrig_component'):
+                    continue
+                
+                component = bone.cloudrig_component
+                if not component or not hasattr(component, 'params'):
+                    continue
+                
+                params = component.params
+                
+                for namespace, param_name in all_param_paths:
+                    if hasattr(params, namespace):
+                        param_group = getattr(params, namespace)
+                        if hasattr(param_group, param_name):
+                            shape_param = getattr(param_group, param_name)
+                            if hasattr(shape_param, 'custom_shape') and shape_param.custom_shape == widget:
+                                return bone
+                            # 直接比较
+                            if shape_param == widget:
+                                return bone
+    
+    return None
+
+
+def is_cloudrig_component(bone):
+    """
+    检查骨骼是否是任何支持的 CloudRig 组件。
+    
+    Args:
+        bone: PoseBone
+    
+    Returns:
+        bool
+    """
+    return get_cloudrig_component_type(bone) is not None
+
+
+def is_cloudrig_spine_toon(bone):
+    """
+    检查骨骼是否是 Spine: Cartoon 组件（或任何支持的 CloudRig 组件）。
+    保留此函数名以保持向后兼容。
+    
+    Args:
+        bone: PoseBone
+    
+    Returns:
+        bool
+    """
+    # 使用新的通用函数
+    component_type = get_cloudrig_component_type(bone)
+    return component_type is not None

--- a/functions/main_functions.py
+++ b/functions/main_functions.py
@@ -871,8 +871,18 @@ def update_cloudrig_widget(bone, param_value, widget_obj, component_type=None):
             shape_param.custom_shape = widget_obj
             
             # 刷新 CloudRig GPU 预览
+            # 通过 rna_ancestors 找到并标记所有相关组件为脏
+            if hasattr(shape_param, 'rna_ancestors'):
+                for ancestor in shape_param.rna_ancestors():
+                    if hasattr(ancestor, 'overlay_is_dirty'):
+                        ancestor.overlay_is_dirty = True
+            # 同时标记直接组件
             if hasattr(component, 'overlay_is_dirty'):
                 component.overlay_is_dirty = True
+            # 标记 inherited_component（如果存在）
+            if hasattr(component, 'inherited_component') and component.inherited_component:
+                if hasattr(component.inherited_component, 'overlay_is_dirty'):
+                    component.inherited_component.overlay_is_dirty = True
             
             return True
     except Exception as e:

--- a/functions/preview_overlay.py
+++ b/functions/preview_overlay.py
@@ -1,0 +1,198 @@
+"""
+Bone Widget 预览线绘制模块
+使用 GPU 在空间中绘制自定义骨骼的虚线预览
+"""
+
+import bpy
+import gpu
+from gpu_extras.batch import batch_for_shader
+from mathutils import Matrix, Vector
+
+# 全局状态
+PREVIEW_HANDLER = None
+PREVIEW_WIDGET_DATA = None
+PREVIEW_BONE = None
+
+
+def draw_widget_preview():
+    """在 3D 视图中绘制 widget 预览线"""
+    global PREVIEW_WIDGET_DATA, PREVIEW_BONE
+    
+    if not PREVIEW_WIDGET_DATA or not PREVIEW_BONE:
+        return
+    
+    context = bpy.context
+    
+    # 获取 widget 数据
+    widget_data = PREVIEW_WIDGET_DATA
+    
+    # 构建线条数据
+    lines = []
+    
+    # 获取顶点和边
+    vertices = widget_data.get('vertices', [])
+    edges = widget_data.get('edges', [])
+    
+    if not vertices or not edges:
+        return
+    
+    # 计算变换矩阵
+    armature = PREVIEW_BONE.id_data
+    bone = PREVIEW_BONE.bone
+    
+    # 基础变换：骨骼位置
+    matrix = armature.matrix_world @ bone.matrix_local
+    
+    # 应用 CloudRig 控件的变换（如果有）
+    if hasattr(PREVIEW_BONE, 'custom_shape_transform') and PREVIEW_BONE.custom_shape_transform:
+        matrix = armature.matrix_world @ PREVIEW_BONE.custom_shape_transform.bone.matrix_local
+    
+    # 应用 Bone Widget 的变换参数
+    loc = PREVIEW_BONE.custom_shape_translation
+    rot = PREVIEW_BONE.custom_shape_rotation_euler
+    scale = PREVIEW_BONE.custom_shape_scale_xyz.copy()
+    
+    if PREVIEW_BONE.use_custom_shape_bone_size:
+        scale *= bone.length
+    
+    custom_matrix = Matrix.LocRotScale(loc, rot, scale)
+    matrix = matrix @ custom_matrix
+    
+    # 转换顶点并构建线条
+    transformed_verts = [matrix @ Vector(v) for v in vertices]
+    
+    for edge in edges:
+        if len(edge) == 2:
+            v1 = transformed_verts[edge[0]]
+            v2 = transformed_verts[edge[1]]
+            lines.append((v1, v2))
+    
+    if not lines:
+        return
+    
+    # 创建 GPU Batch
+    shader = gpu.shader.from_builtin('POLYLINE_FLAT_COLOR')
+    shader.bind()
+    
+    # 设置视口大小
+    shader.uniform_float("viewportSize", gpu.state.viewport_get()[2:])
+    
+    # 设置线宽
+    if bpy.app.version >= (4, 2, 0):
+        line_width = PREVIEW_BONE.custom_shape_wire_width
+    else:
+        line_width = 2.0
+    shader.uniform_float("lineWidth", line_width)
+    
+    # 准备顶点数据（虚线效果）
+    dash_length = 0.05  # 虚线段长度
+    positions = []
+    colors = []
+    
+    # 主题颜色
+    theme = context.preferences.themes["Default"]
+    color_normal = theme.bone_color_sets[0].normal
+    color = (color_normal.r, color_normal.g, color_normal.b, 0.8)  # 80% 透明度
+    
+    for start, end in lines:
+        # 计算虚线
+        direction = (end - start).normalized()
+        length = (end - start).length
+        
+        if length < 0.0001:
+            continue
+        
+        num_segments = max(1, int(length / dash_length))
+        
+        for i in range(num_segments):
+            # 只绘制偶数段，形成虚线效果
+            if i % 2 == 0:
+                seg_start = start + direction * (i * dash_length)
+                seg_end = start + direction * (min((i + 1) * dash_length, length))
+                positions.extend([seg_start, seg_end])
+                colors.extend([color, color])
+    
+    if positions:
+        batch = batch_for_shader(shader, 'LINES', {"pos": positions, "color": colors})
+        batch.draw(shader)
+
+
+def enable_widget_preview(bone, widget_data):
+    """启用 widget 预览线绘制
+    
+    Args:
+        bone: 目标骨骼 (PoseBone)
+        widget_data: widget 数据字典，包含 'vertices' 和 'edges'
+    """
+    global PREVIEW_HANDLER, PREVIEW_WIDGET_DATA, PREVIEW_BONE
+    
+    # 禁用之前的预览
+    disable_widget_preview()
+    
+    PREVIEW_WIDGET_DATA = widget_data
+    PREVIEW_BONE = bone
+    
+    # 添加绘制处理器
+    if PREVIEW_HANDLER is None:
+        PREVIEW_HANDLER = bpy.types.SpaceView3D.draw_handler_add(
+            draw_widget_preview,
+            (),
+            'WINDOW',
+            'POST_VIEW'
+        )
+    
+    # 强制刷新视图
+    for area in bpy.context.screen.areas:
+        if area.type == 'VIEW_3D':
+            area.tag_redraw()
+
+
+def disable_widget_preview():
+    """禁用 widget 预览线绘制"""
+    global PREVIEW_HANDLER, PREVIEW_WIDGET_DATA, PREVIEW_BONE
+    
+    if PREVIEW_HANDLER is not None:
+        bpy.types.SpaceView3D.draw_handler_remove(PREVIEW_HANDLER, 'WINDOW')
+        PREVIEW_HANDLER = None
+    
+    PREVIEW_WIDGET_DATA = None
+    PREVIEW_BONE = None
+    
+    # 强制刷新视图
+    if bpy.context and bpy.context.screen:
+        for area in bpy.context.screen.areas:
+            if area.type == 'VIEW_3D':
+                area.tag_redraw()
+
+
+def update_widget_preview(bone, widget_data):
+    """更新预览线数据
+    
+    Args:
+        bone: 目标骨骼 (PoseBone)
+        widget_data: widget 数据字典
+    """
+    global PREVIEW_WIDGET_DATA, PREVIEW_BONE
+    
+    PREVIEW_WIDGET_DATA = widget_data
+    PREVIEW_BONE = bone
+    
+    # 刷新视图
+    for area in bpy.context.screen.areas:
+        if area.type == 'VIEW_3D':
+            area.tag_redraw()
+
+
+def is_preview_active():
+    """检查预览是否处于活动状态"""
+    return PREVIEW_HANDLER is not None
+
+
+def register():
+    """注册模块"""
+    pass
+
+
+def unregister():
+    """注销模块"""
+    disable_widget_preview()

--- a/operators.py
+++ b/operators.py
@@ -180,25 +180,27 @@ class BONEWIDGET_OT_create_widget(bpy.types.Operator):
         
         bw_settings = context.scene.bw_settings
         
+        # 组件类型到参数属性的映射
+        component_param_map = {
+            'Spine: Cartoon': 'cloudrig_spine_toon_param',
+            'Spine: IK/FK': 'cloudrig_spine_ikfk_param',
+            'Limb: Biped Leg': 'cloudrig_limb_leg_param',
+            'Chain: FK': 'cloudrig_chain_fk_param',
+            'Chain: IK': 'cloudrig_chain_ik_param',
+            'Chain: Toon': 'cloudrig_chain_toon_param',
+            'Aim': 'cloudrig_aim_param',
+            'Single Control': 'cloudrig_single_control_param',
+            'Lattice': 'cloudrig_lattice_param',
+            'Curve: With Hooks': 'cloudrig_curve_hooks_param',
+        }
+        
         for bone in bpy.context.selected_pose_bones:
             # 检测 CloudRig 组件类型
             component_type = get_cloudrig_component_type(bone)
             
-            if component_type == 'Spine: Cartoon':
-                cloudrig_param = bw_settings.cloudrig_spine_toon_param
-                if cloudrig_param != 'NONE':
-                    widget_obj = create_widget(
-                        bone, widget_data, self.relative_size, global_size, slide, self.rotation,
-                        get_collection(context), use_face_data, self.wireframe_width, 
-                        cloudrig_param=cloudrig_param
-                    )
-                    if widget_obj:
-                        update_cloudrig_widget(bone, cloudrig_param, widget_obj, component_type)
-                        self.report({'INFO'}, f"Updated {component_type} {cloudrig_param}")
-                    continue
-            
-            elif component_type == 'Limb: Biped Leg':
-                cloudrig_param = bw_settings.cloudrig_limb_leg_param
+            if component_type and component_type in component_param_map:
+                param_attr = component_param_map[component_type]
+                cloudrig_param = getattr(bw_settings, param_attr)
                 if cloudrig_param != 'NONE':
                     widget_obj = create_widget(
                         bone, widget_data, self.relative_size, global_size, slide, self.rotation,
@@ -237,15 +239,24 @@ class BONEWIDGET_OT_edit_widget(bpy.types.Operator):
         bone = context.active_pose_bone
         component_type = get_cloudrig_component_type(bone)
         
-        if component_type == 'Spine: Cartoon':
-            bw_settings = context.scene.bw_settings
-            param = bw_settings.cloudrig_spine_toon_param
-            return param != 'NONE'
-        
-        elif component_type == 'Limb: Biped Leg':
-            bw_settings = context.scene.bw_settings
-            param = bw_settings.cloudrig_limb_leg_param
-            return param != 'NONE'
+        if component_type:
+            # 组件类型到参数属性的映射
+            component_param_map = {
+                'Spine: Cartoon': 'cloudrig_spine_toon_param',
+                'Spine: IK/FK': 'cloudrig_spine_ikfk_param',
+                'Limb: Biped Leg': 'cloudrig_limb_leg_param',
+                'Chain: FK': 'cloudrig_chain_fk_param',
+                'Chain: IK': 'cloudrig_chain_ik_param',
+                'Chain: Toon': 'cloudrig_chain_toon_param',
+                'Aim': 'cloudrig_aim_param',
+                'Single Control': 'cloudrig_single_control_param',
+                'Lattice': 'cloudrig_lattice_param',
+                'Curve: With Hooks': 'cloudrig_curve_hooks_param',
+            }
+            if component_type in component_param_map:
+                bw_settings = context.scene.bw_settings
+                param_attr = component_param_map[component_type]
+                return getattr(bw_settings, param_attr) != 'NONE'
         
         return False
 
@@ -253,17 +264,32 @@ class BONEWIDGET_OT_edit_widget(bpy.types.Operator):
         active_bone = context.active_pose_bone
         bw_settings = context.scene.bw_settings
         
+        # 组件类型到参数属性的映射
+        component_param_map = {
+            'Spine: Cartoon': 'cloudrig_spine_toon_param',
+            'Spine: IK/FK': 'cloudrig_spine_ikfk_param',
+            'Limb: Biped Leg': 'cloudrig_limb_leg_param',
+            'Chain: FK': 'cloudrig_chain_fk_param',
+            'Chain: IK': 'cloudrig_chain_ik_param',
+            'Chain: Toon': 'cloudrig_chain_toon_param',
+            'Aim': 'cloudrig_aim_param',
+            'Single Control': 'cloudrig_single_control_param',
+            'Lattice': 'cloudrig_lattice_param',
+            'Curve: With Hooks': 'cloudrig_curve_hooks_param',
+        }
+        
         try:
             # 检测 CloudRig 组件类型
             component_type = get_cloudrig_component_type(active_bone)
             
-            if component_type == 'Spine: Cartoon':
-                param = bw_settings.cloudrig_spine_toon_param
+            if component_type and component_type in component_param_map:
+                param_attr = component_param_map[component_type]
+                param = getattr(bw_settings, param_attr)
                 if param != 'NONE':
                     widget = get_cloudrig_widget(active_bone, param, component_type)
                     if widget:
                         edit_widget(active_bone, widget)
-                        self.report({'INFO'}, f"Editing Spine: Cartoon {param}")
+                        self.report({'INFO'}, f"Editing {component_type} {param}")
                         return {'FINISHED'}
                     else:
                         # 自动创建
@@ -279,32 +305,7 @@ class BONEWIDGET_OT_edit_widget(bpy.types.Operator):
                         if new_widget:
                             update_cloudrig_widget(active_bone, param, new_widget, component_type)
                             edit_widget(active_bone, new_widget)
-                            self.report({'INFO'}, f"Created and editing Spine: Cartoon {param}")
-                            return {'FINISHED'}
-            
-            elif component_type == 'Limb: Biped Leg':
-                param = bw_settings.cloudrig_limb_leg_param
-                if param != 'NONE':
-                    widget = get_cloudrig_widget(active_bone, param, component_type)
-                    if widget:
-                        edit_widget(active_bone, widget)
-                        self.report({'INFO'}, f"Editing Limb: Leg {param}")
-                        return {'FINISHED'}
-                    else:
-                        # 自动创建
-                        widget_data = get_widget_data(context.window_manager.widget_list)
-                        collection = get_collection(context)
-                        new_widget = create_widget(
-                            active_bone, widget_data, 
-                            relative=True, size=(1.0, 1.0, 1.0), 
-                            slide=(0.0, 0.0, 0.0), rotation=Euler((0.0, 0.0, 0.0)),
-                            collection=collection, use_face_data=False, 
-                            wireframe_width=2.0, cloudrig_param=param
-                        )
-                        if new_widget:
-                            update_cloudrig_widget(active_bone, param, new_widget, component_type)
-                            edit_widget(active_bone, new_widget)
-                            self.report({'INFO'}, f"Created and editing Limb: Leg {param}")
+                            self.report({'INFO'}, f"Created and editing {component_type} {param}")
                             return {'FINISHED'}
             
             # 标准 Bone Widget 行为

--- a/operators.py
+++ b/operators.py
@@ -1,9 +1,11 @@
 import bpy
 import os
+from mathutils import Euler
 
 from .functions.main_functions import (
     find_match_bones,
     from_widget_find_bone,
+    find_bone_from_cloudrig_widget,
     symmetrize_widget_helper,
     match_bone_matrix,
     create_widget,
@@ -20,6 +22,12 @@ from .functions.main_functions import (
     set_bone_color,
     copy_bone_color,
     get_preferences,
+    update_cloudrig_widget,
+    update_cloudrig_spine_toon,
+    is_cloudrig_spine_toon,
+    is_cloudrig_component,
+    get_cloudrig_component_type,
+    get_cloudrig_widget,
 )
 from .functions.json_functions import (
     add_remove_widgets,
@@ -169,9 +177,43 @@ class BONEWIDGET_OT_create_widget(bpy.types.Operator):
         global_size = self.global_size_advanced if self.advanced_options else (
             self.global_size_simple,) * 3
         use_face_data = self.use_face_data if self.advanced_options else False
+        
+        bw_settings = context.scene.bw_settings
+        
         for bone in bpy.context.selected_pose_bones:
+            # 检测 CloudRig 组件类型
+            component_type = get_cloudrig_component_type(bone)
+            
+            if component_type == 'Spine: Cartoon':
+                cloudrig_param = bw_settings.cloudrig_spine_toon_param
+                if cloudrig_param != 'NONE':
+                    widget_obj = create_widget(
+                        bone, widget_data, self.relative_size, global_size, slide, self.rotation,
+                        get_collection(context), use_face_data, self.wireframe_width, 
+                        cloudrig_param=cloudrig_param
+                    )
+                    if widget_obj:
+                        update_cloudrig_widget(bone, cloudrig_param, widget_obj, component_type)
+                        self.report({'INFO'}, f"Updated {component_type} {cloudrig_param}")
+                    continue
+            
+            elif component_type == 'Limb: Biped Leg':
+                cloudrig_param = bw_settings.cloudrig_limb_leg_param
+                if cloudrig_param != 'NONE':
+                    widget_obj = create_widget(
+                        bone, widget_data, self.relative_size, global_size, slide, self.rotation,
+                        get_collection(context), use_face_data, self.wireframe_width, 
+                        cloudrig_param=cloudrig_param
+                    )
+                    if widget_obj:
+                        update_cloudrig_widget(bone, cloudrig_param, widget_obj, component_type)
+                        self.report({'INFO'}, f"Updated {component_type} {cloudrig_param}")
+                    continue
+            
+            # 标准 Bone Widget 行为
             create_widget(bone, widget_data, self.relative_size, global_size, slide, self.rotation,
                           get_collection(context), use_face_data, self.wireframe_width)
+        
         return {'FINISHED'}
 
 
@@ -183,15 +225,92 @@ class BONEWIDGET_OT_edit_widget(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        return (context.object and context.object.type == 'ARMATURE' and context.object.mode == 'POSE'
-                and context.active_pose_bone is not None and context.active_pose_bone.custom_shape is not None)
+        if not (context.object and context.object.type == 'ARMATURE' and context.object.mode == 'POSE'
+                and context.active_pose_bone is not None):
+            return False
+        
+        # 标准模式：检查骨骼是否有 custom_shape
+        if context.active_pose_bone.custom_shape is not None:
+            return True
+        
+        # CloudRig 模式：检查是否支持任何 CloudRig 组件
+        bone = context.active_pose_bone
+        component_type = get_cloudrig_component_type(bone)
+        
+        if component_type == 'Spine: Cartoon':
+            bw_settings = context.scene.bw_settings
+            param = bw_settings.cloudrig_spine_toon_param
+            return param != 'NONE'
+        
+        elif component_type == 'Limb: Biped Leg':
+            bw_settings = context.scene.bw_settings
+            param = bw_settings.cloudrig_limb_leg_param
+            return param != 'NONE'
+        
+        return False
 
     def execute(self, context):
         active_bone = context.active_pose_bone
+        bw_settings = context.scene.bw_settings
+        
         try:
+            # 检测 CloudRig 组件类型
+            component_type = get_cloudrig_component_type(active_bone)
+            
+            if component_type == 'Spine: Cartoon':
+                param = bw_settings.cloudrig_spine_toon_param
+                if param != 'NONE':
+                    widget = get_cloudrig_widget(active_bone, param, component_type)
+                    if widget:
+                        edit_widget(active_bone, widget)
+                        self.report({'INFO'}, f"Editing Spine: Cartoon {param}")
+                        return {'FINISHED'}
+                    else:
+                        # 自动创建
+                        widget_data = get_widget_data(context.window_manager.widget_list)
+                        collection = get_collection(context)
+                        new_widget = create_widget(
+                            active_bone, widget_data, 
+                            relative=True, size=(1.0, 1.0, 1.0), 
+                            slide=(0.0, 0.0, 0.0), rotation=Euler((0.0, 0.0, 0.0)),
+                            collection=collection, use_face_data=False, 
+                            wireframe_width=2.0, cloudrig_param=param
+                        )
+                        if new_widget:
+                            update_cloudrig_widget(active_bone, param, new_widget, component_type)
+                            edit_widget(active_bone, new_widget)
+                            self.report({'INFO'}, f"Created and editing Spine: Cartoon {param}")
+                            return {'FINISHED'}
+            
+            elif component_type == 'Limb: Biped Leg':
+                param = bw_settings.cloudrig_limb_leg_param
+                if param != 'NONE':
+                    widget = get_cloudrig_widget(active_bone, param, component_type)
+                    if widget:
+                        edit_widget(active_bone, widget)
+                        self.report({'INFO'}, f"Editing Limb: Leg {param}")
+                        return {'FINISHED'}
+                    else:
+                        # 自动创建
+                        widget_data = get_widget_data(context.window_manager.widget_list)
+                        collection = get_collection(context)
+                        new_widget = create_widget(
+                            active_bone, widget_data, 
+                            relative=True, size=(1.0, 1.0, 1.0), 
+                            slide=(0.0, 0.0, 0.0), rotation=Euler((0.0, 0.0, 0.0)),
+                            collection=collection, use_face_data=False, 
+                            wireframe_width=2.0, cloudrig_param=param
+                        )
+                        if new_widget:
+                            update_cloudrig_widget(active_bone, param, new_widget, component_type)
+                            edit_widget(active_bone, new_widget)
+                            self.report({'INFO'}, f"Created and editing Limb: Leg {param}")
+                            return {'FINISHED'}
+            
+            # 标准 Bone Widget 行为
             edit_widget(active_bone)
-        except KeyError:
-            self.report({'INFO'}, 'This widget is the Widget Collection')
+        except KeyError as e:
+            self.report({'INFO'}, str(e))
         return {'FINISHED'}
 
 
@@ -208,8 +327,18 @@ class BONEWIDGET_OT_return_to_armature(bpy.types.Operator):
 
     def execute(self, context):
         b = bpy.context.object
-        if from_widget_find_bone(bpy.context.object):
-            return_to_armature(bpy.context.object)
+        
+        # 先尝试标准查找
+        bone = from_widget_find_bone(b)
+        
+        # 如果没找到，尝试 CloudRig 查找
+        if bone is None:
+            bone = find_bone_from_cloudrig_widget(b)
+        
+        if bone:
+            success = return_to_armature(b, bone)
+            if not success:
+                self.report({'WARNING'}, 'Failed to return to armature')
         else:
             self.report({'INFO'}, 'Object is not a bone widget')
         return {'FINISHED'}

--- a/operators.py
+++ b/operators.py
@@ -62,6 +62,25 @@ from .classes import ColorSet
 from bpy.props import FloatProperty, BoolProperty, FloatVectorProperty, IntVectorProperty, StringProperty, EnumProperty
 
 
+def _mark_cloudrig_dirty(bone):
+    """标记 CloudRig 组件为脏以刷新 GPU 预览"""
+    if not hasattr(bone, 'cloudrig_component'):
+        return
+    
+    component = bone.cloudrig_component
+    if not component:
+        return
+    
+    # 标记组件为脏
+    if hasattr(component, 'overlay_is_dirty'):
+        component.overlay_is_dirty = True
+    
+    # 标记 inherited_component
+    if hasattr(component, 'inherited_component') and component.inherited_component:
+        if hasattr(component.inherited_component, 'overlay_is_dirty'):
+            component.inherited_component.overlay_is_dirty = True
+
+
 class BONEWIDGET_OT_shared_property_group(bpy.types.PropertyGroup):
     """Storage class for Shared Attribute Properties"""
 
@@ -296,6 +315,8 @@ class BONEWIDGET_OT_edit_widget(bpy.types.Operator):
                     widget = get_cloudrig_widget(active_bone, param, component_type)
                     if widget:
                         edit_widget(active_bone, widget)
+                        # 标记 CloudRig 组件为脏以刷新 GPU 预览
+                        _mark_cloudrig_dirty(active_bone)
                         self.report({'INFO'}, f"Editing {component_type} {param}")
                         return {'FINISHED'}
                     else:

--- a/operators.py
+++ b/operators.py
@@ -12,6 +12,7 @@ from .functions.main_functions import (
     edit_widget,
     return_to_armature,
     get_collection,
+    get_widget_collection,
     get_view_layer_collection,
     recursive_layer_collection,
     delete_unused_widgets,
@@ -206,7 +207,7 @@ class BONEWIDGET_OT_create_widget(bpy.types.Operator):
                 if cloudrig_param != 'NONE':
                     widget_obj = create_widget(
                         bone, widget_data, self.relative_size, global_size, slide, self.rotation,
-                        get_collection(context), use_face_data, self.wireframe_width, 
+                        get_widget_collection(context), use_face_data, self.wireframe_width, 
                         cloudrig_param=cloudrig_param
                     )
                     if widget_obj:
@@ -216,7 +217,7 @@ class BONEWIDGET_OT_create_widget(bpy.types.Operator):
             
             # 标准 Bone Widget 行为
             create_widget(bone, widget_data, self.relative_size, global_size, slide, self.rotation,
-                          get_collection(context), use_face_data, self.wireframe_width)
+                          get_widget_collection(context), use_face_data, self.wireframe_width)
         
         return {'FINISHED'}
 
@@ -300,7 +301,7 @@ class BONEWIDGET_OT_edit_widget(bpy.types.Operator):
                     else:
                         # 自动创建
                         widget_data = get_widget_data(context.window_manager.widget_list)
-                        collection = get_collection(context)
+                        collection = get_widget_collection(context)
                         new_widget = create_widget(
                             active_bone, widget_data, 
                             relative=True, size=(1.0, 1.0, 1.0), 
@@ -1093,7 +1094,7 @@ class BONEWIDGET_OT_add_object_as_widget(bpy.types.Operator):
         return (len(context.selected_objects) == 2 and context.object.mode == 'POSE')
 
     def execute(self, context):
-        add_object_as_widget(context, get_collection(context))
+        add_object_as_widget(context, get_widget_collection(context))
         return {'FINISHED'}
 
 

--- a/operators.py
+++ b/operators.py
@@ -191,6 +191,8 @@ class BONEWIDGET_OT_create_widget(bpy.types.Operator):
             'Aim': 'cloudrig_aim_param',
             'Single Control': 'cloudrig_single_control_param',
             'Lattice': 'cloudrig_lattice_param',
+            'Limb: Generic': 'cloudrig_limb_generic_param',
+            'Shoulder Bone': 'cloudrig_shoulder_param',
             'Curve: With Hooks': 'cloudrig_curve_hooks_param',
         }
         
@@ -251,6 +253,8 @@ class BONEWIDGET_OT_edit_widget(bpy.types.Operator):
                 'Aim': 'cloudrig_aim_param',
                 'Single Control': 'cloudrig_single_control_param',
                 'Lattice': 'cloudrig_lattice_param',
+                'Limb: Generic': 'cloudrig_limb_generic_param',
+                'Shoulder Bone': 'cloudrig_shoulder_param',
                 'Curve: With Hooks': 'cloudrig_curve_hooks_param',
             }
             if component_type in component_param_map:
@@ -275,6 +279,8 @@ class BONEWIDGET_OT_edit_widget(bpy.types.Operator):
             'Aim': 'cloudrig_aim_param',
             'Single Control': 'cloudrig_single_control_param',
             'Lattice': 'cloudrig_lattice_param',
+            'Limb: Generic': 'cloudrig_limb_generic_param',
+            'Shoulder Bone': 'cloudrig_shoulder_param',
             'Curve: With Hooks': 'cloudrig_curve_hooks_param',
         }
         

--- a/panels.py
+++ b/panels.py
@@ -70,18 +70,34 @@ class BONEWIDGET_PT_bw_panel_main(BONEWIDGET_PT_bw_panel, bpy.types.Panel):
         if context.mode == "POSE" and context.active_pose_bone:
             bone = context.active_pose_bone
             component_type = get_cloudrig_component_type(bone)
+            bw_settings = context.scene.bw_settings
             
-            if component_type == 'Spine: Cartoon':
+            if component_type:
                 box = layout.box()
-                box.label(text="Spine: Cartoon:", icon='ARMATURE_DATA')
+                box.label(text=f"{component_type}:", icon='ARMATURE_DATA')
                 row = box.row()
-                row.prop(context.scene.bw_settings, "cloudrig_spine_toon_param", text="")
-            
-            elif component_type == 'Limb: Biped Leg':
-                box = layout.box()
-                box.label(text="Limb: Biped Leg:", icon='ARMATURE_DATA')
-                row = box.row()
-                row.prop(context.scene.bw_settings, "cloudrig_limb_leg_param", text="")
+                
+                # 根据组件类型显示对应的枚举
+                if component_type == 'Spine: Cartoon':
+                    row.prop(bw_settings, "cloudrig_spine_toon_param", text="")
+                elif component_type == 'Spine: IK/FK':
+                    row.prop(bw_settings, "cloudrig_spine_ikfk_param", text="")
+                elif component_type == 'Limb: Biped Leg':
+                    row.prop(bw_settings, "cloudrig_limb_leg_param", text="")
+                elif component_type == 'Chain: FK':
+                    row.prop(bw_settings, "cloudrig_chain_fk_param", text="")
+                elif component_type == 'Chain: IK':
+                    row.prop(bw_settings, "cloudrig_chain_ik_param", text="")
+                elif component_type == 'Chain: Toon':
+                    row.prop(bw_settings, "cloudrig_chain_toon_param", text="")
+                elif component_type == 'Aim':
+                    row.prop(bw_settings, "cloudrig_aim_param", text="")
+                elif component_type == 'Single Control':
+                    row.prop(bw_settings, "cloudrig_single_control_param", text="")
+                elif component_type == 'Lattice':
+                    row.prop(bw_settings, "cloudrig_lattice_param", text="")
+                elif component_type == 'Curve: With Hooks':
+                    row.prop(bw_settings, "cloudrig_curve_hooks_param", text="")
 
         layout.separator()
 

--- a/panels.py
+++ b/panels.py
@@ -4,6 +4,8 @@ from .props import PresetColorSetItem
 from .functions.main_functions import (
     recursive_layer_collection,
     get_preferences,
+    is_cloudrig_spine_toon,
+    get_cloudrig_component_type,
 )
 from .functions.preview_functions import (
     create_preview_collection,
@@ -63,6 +65,23 @@ class BONEWIDGET_PT_bw_panel_main(BONEWIDGET_PT_bw_panel, bpy.types.Panel):
         else:
             row.operator("bonewidget.return_to_armature",
                          icon="LOOP_BACK", text='To bone')
+
+        # CloudRig 组件集成
+        if context.mode == "POSE" and context.active_pose_bone:
+            bone = context.active_pose_bone
+            component_type = get_cloudrig_component_type(bone)
+            
+            if component_type == 'Spine: Cartoon':
+                box = layout.box()
+                box.label(text="Spine: Cartoon:", icon='ARMATURE_DATA')
+                row = box.row()
+                row.prop(context.scene.bw_settings, "cloudrig_spine_toon_param", text="")
+            
+            elif component_type == 'Limb: Biped Leg':
+                box = layout.box()
+                box.label(text="Limb: Biped Leg:", icon='ARMATURE_DATA')
+                row = box.row()
+                row.prop(context.scene.bw_settings, "cloudrig_limb_leg_param", text="")
 
         layout.separator()
 

--- a/panels.py
+++ b/panels.py
@@ -96,6 +96,10 @@ class BONEWIDGET_PT_bw_panel_main(BONEWIDGET_PT_bw_panel, bpy.types.Panel):
                     row.prop(bw_settings, "cloudrig_single_control_param", text="")
                 elif component_type == 'Lattice':
                     row.prop(bw_settings, "cloudrig_lattice_param", text="")
+                elif component_type == 'Limb: Generic':
+                    row.prop(bw_settings, "cloudrig_limb_generic_param", text="")
+                elif component_type == 'Shoulder Bone':
+                    row.prop(bw_settings, "cloudrig_shoulder_param", text="")
                 elif component_type == 'Curve: With Hooks':
                     row.prop(bw_settings, "cloudrig_curve_hooks_param", text="")
 

--- a/props.py
+++ b/props.py
@@ -122,6 +122,25 @@ CLOUDRIG_LATTICE_ITEMS = [
     ('LATTICE_SHAPE', "Lattice", "Update lattice.shape_lattice"),
 ]
 
+# CloudRig Limb: Generic 形状参数枚举
+CLOUDRIG_LIMB_GENERIC_ITEMS = [
+    ('NONE', "None", "Standard Bone Widget behavior"),
+    ('LIMB_STRETCH', "Stretch Shape", "Update chain.shape_stretch"),
+    ('LIMB_STRETCH_ENDS', "Stretch Ends", "Update chain.shape_stretch_ends"),
+    ('LIMB_FK', "FK Shape", "Update fk_chain.shape_fk"),
+    ('LIMB_FK_ROOT', "FK Root Shape", "Update fk_chain.shape_fk_root"),
+    ('LIMB_IK_MASTER', "IK Master", "Update ik_chain.shape_ik_master"),
+    ('LIMB_IK_FIRST', "First IK", "Update ik_chain.shape_ik_first"),
+    ('LIMB_IK_POLE', "IK Pole", "Update ik_chain.shape_pole"),
+    ('LIMB_RUBBERHOSE', "Rubberhose", "Update limb.shape_rubberhose"),
+]
+
+# CloudRig Shoulder Bone 形状参数枚举
+CLOUDRIG_SHOULDER_ITEMS = [
+    ('NONE', "None", "Standard Bone Widget behavior"),
+    ('SHOULDER_SHAPE', "Shoulder", "Update shoulder.shape_shoulder"),
+]
+
 # CloudRig Curve: With Hooks 形状参数枚举
 CLOUDRIG_CURVE_HOOKS_ITEMS = [
     ('NONE', "None", "Standard Bone Widget behavior"),
@@ -132,6 +151,23 @@ CLOUDRIG_CURVE_HOOKS_ITEMS = [
     ('CURVE_BEZIER', "Bezier", "Update curve.shape_bezier"),
     ('CURVE_SPLINE_ROOT', "Spline Root", "Update curve.shape_spline_root"),
     ('CURVE_RADIUS', "Radius", "Update curve.shape_radius"),
+]
+
+# CloudRig 组件类型枚举（用于显示）
+CLOUDRIG_COMPONENT_TYPE_ITEMS = [
+    ('NONE', "None", "No CloudRig component"),
+    ('Spine: Cartoon', "Spine: Cartoon", "Spine Cartoon component"),
+    ('Spine: IK/FK', "Spine: IK/FK", "Spine IK/FK component"),
+    ('Limb: Biped Leg', "Limb: Biped Leg", "Limb Biped Leg component"),
+    ('Limb: Generic', "Limb: Generic", "Limb Generic component"),
+    ('Chain: FK', "Chain: FK", "Chain FK component"),
+    ('Chain: IK', "Chain: IK", "Chain IK component"),
+    ('Chain: Toon', "Chain: Toon", "Chain Toon component"),
+    ('Aim', "Aim", "Aim component"),
+    ('Single Control', "Single Control", "Single Control component"),
+    ('Shoulder Bone', "Shoulder Bone", "Shoulder Bone component"),
+    ('Lattice', "Lattice", "Lattice component"),
+    ('Curve: With Hooks', "Curve: With Hooks", "Curve With Hooks component"),
 ]
 
 
@@ -237,6 +273,22 @@ class BW_Settings(PropertyGroup):
         name="Shape",
         description="Select CloudRig Lattice shape parameter to update",
         items=CLOUDRIG_LATTICE_ITEMS,
+        default='NONE',
+    )
+
+    # CloudRig Limb: Generic 集成
+    cloudrig_limb_generic_param: EnumProperty(
+        name="Shape",
+        description="Select CloudRig Limb: Generic shape parameter to update",
+        items=CLOUDRIG_LIMB_GENERIC_ITEMS,
+        default='NONE',
+    )
+
+    # CloudRig Shoulder Bone 集成
+    cloudrig_shoulder_param: EnumProperty(
+        name="Shape",
+        description="Select CloudRig Shoulder Bone shape parameter to update",
+        items=CLOUDRIG_SHOULDER_ITEMS,
         default='NONE',
     )
 

--- a/props.py
+++ b/props.py
@@ -62,15 +62,76 @@ CLOUDRIG_LIMB_LEG_ITEMS = [
     ('LEG_FK_ROOT', "FK Root Shape", "Update fk_chain.shape_fk_root"),
     ('LEG_IK_MASTER', "IK Master", "Update ik_chain.shape_ik_master"),
     ('LEG_IK_FIRST', "First IK", "Update ik_chain.shape_ik_first"),
-    ('LEG_IK_POLE', "IK Pole", "Update ik_chain.shape_ik_pole"),
+    ('LEG_IK_POLE', "IK Pole", "Update ik_chain.shape_pole"),
     ('LEG_FOOT_ROLL', "Foot Roll", "Update leg.shape_footroll"),
 ]
 
-# 组件类型枚举
-CLOUDRIG_COMPONENT_TYPE_ITEMS = [
-    ('NONE', "None", "No CloudRig component"),
-    ('SPINE_TOON', "Spine: Cartoon", "Spine Cartoon component"),
-    ('LIMB_LEG', "Limb: Biped Leg", "Limb Biped Leg component"),
+# CloudRig Spine: IK/FK 形状参数枚举
+CLOUDRIG_SPINE_IKFK_ITEMS = [
+    ('NONE', "None", "Standard Bone Widget behavior"),
+    ('SHAPE_HIP', "Hip", "Update spine.shape_hip"),
+    ('SHAPE_CHEST', "Chest", "Update spine.shape_chest"),
+    ('SHAPE_TORSO', "Torso", "Update spine.shape_torso"),
+    ('SHAPE_IK', "IK Shape", "Update spine.shape_ik"),
+]
+
+# CloudRig Chain: FK 形状参数枚举
+CLOUDRIG_CHAIN_FK_ITEMS = [
+    ('NONE', "None", "Standard Bone Widget behavior"),
+    ('FK_SHAPE', "FK Shape", "Update fk_chain.shape_fk"),
+    ('FK_ROOT_SHAPE', "FK Root Shape", "Update fk_chain.shape_fk_root"),
+]
+
+# CloudRig Chain: IK 形状参数枚举
+CLOUDRIG_CHAIN_IK_ITEMS = [
+    ('NONE', "None", "Standard Bone Widget behavior"),
+    ('IK_MASTER', "IK Master", "Update ik_chain.shape_ik_master"),
+    ('IK_FIRST', "First IK", "Update ik_chain.shape_ik_first"),
+    ('IK_POLE', "IK Pole", "Update ik_chain.shape_pole"),
+]
+
+# CloudRig Chain: Toon 形状参数枚举
+CLOUDRIG_CHAIN_TOON_ITEMS = [
+    ('NONE', "None", "Standard Bone Widget behavior"),
+    ('CHAIN_STRETCH', "Stretch Shape", "Update chain.shape_stretch"),
+    ('CHAIN_STRETCH_ENDS', "Stretch Ends", "Update chain.shape_stretch_ends"),
+    ('CHAIN_DEF_CONTROL', "Def Control", "Update chain.shape_def_control"),
+]
+
+# CloudRig Aim 形状参数枚举
+CLOUDRIG_AIM_ITEMS = [
+    ('NONE', "None", "Standard Bone Widget behavior"),
+    ('AIM_TARGET', "Target", "Update aim.shape_target"),
+    ('AIM_EYE', "Eye", "Update aim.shape_eye"),
+    ('AIM_ROOT', "Root", "Update aim.shape_root"),
+    ('AIM_HIGHLIGHT', "Highlight", "Update aim.shape_highlight"),
+    ('AIM_MASTER', "Master", "Update aim.shape_master"),
+]
+
+# CloudRig Single Control 形状参数枚举
+CLOUDRIG_SINGLE_CONTROL_ITEMS = [
+    ('NONE', "None", "Standard Bone Widget behavior"),
+    ('CONTROL_SHAPE', "Control Shape", "Update copy.shape_control"),
+    ('CONTROL_PIVOT', "Pivot", "Update copy.shape_pivot"),
+]
+
+# CloudRig Lattice 形状参数枚举
+CLOUDRIG_LATTICE_ITEMS = [
+    ('NONE', "None", "Standard Bone Widget behavior"),
+    ('LATTICE_ROOT', "Root", "Update lattice.shape_root"),
+    ('LATTICE_SHAPE', "Lattice", "Update lattice.shape_lattice"),
+]
+
+# CloudRig Curve: With Hooks 形状参数枚举
+CLOUDRIG_CURVE_HOOKS_ITEMS = [
+    ('NONE', "None", "Standard Bone Widget behavior"),
+    ('CURVE_ROOT', "Root", "Update curve.shape_root"),
+    ('CURVE_POINT', "Point", "Update curve.shape_point"),
+    ('CURVE_HANDLE', "Handle", "Update curve.shape_handle"),
+    ('CURVE_BEZIER_CENTER', "Bezier Center", "Update curve.shape_bezier_center"),
+    ('CURVE_BEZIER', "Bezier", "Update curve.shape_bezier"),
+    ('CURVE_SPLINE_ROOT', "Spline Root", "Update curve.shape_spline_root"),
+    ('CURVE_RADIUS', "Radius", "Update curve.shape_radius"),
 ]
 
 
@@ -120,6 +181,70 @@ class BW_Settings(PropertyGroup):
         name="Shape",
         description="Select CloudRig Limb: Biped Leg shape parameter to update",
         items=CLOUDRIG_LIMB_LEG_ITEMS,
+        default='NONE',
+    )
+
+    # CloudRig Spine: IK/FK 集成
+    cloudrig_spine_ikfk_param: EnumProperty(
+        name="Shape",
+        description="Select CloudRig Spine: IK/FK shape parameter to update",
+        items=CLOUDRIG_SPINE_IKFK_ITEMS,
+        default='NONE',
+    )
+
+    # CloudRig Chain: FK 集成
+    cloudrig_chain_fk_param: EnumProperty(
+        name="Shape",
+        description="Select CloudRig Chain: FK shape parameter to update",
+        items=CLOUDRIG_CHAIN_FK_ITEMS,
+        default='NONE',
+    )
+
+    # CloudRig Chain: IK 集成
+    cloudrig_chain_ik_param: EnumProperty(
+        name="Shape",
+        description="Select CloudRig Chain: IK shape parameter to update",
+        items=CLOUDRIG_CHAIN_IK_ITEMS,
+        default='NONE',
+    )
+
+    # CloudRig Chain: Toon 集成
+    cloudrig_chain_toon_param: EnumProperty(
+        name="Shape",
+        description="Select CloudRig Chain: Toon shape parameter to update",
+        items=CLOUDRIG_CHAIN_TOON_ITEMS,
+        default='NONE',
+    )
+
+    # CloudRig Aim 集成
+    cloudrig_aim_param: EnumProperty(
+        name="Shape",
+        description="Select CloudRig Aim shape parameter to update",
+        items=CLOUDRIG_AIM_ITEMS,
+        default='NONE',
+    )
+
+    # CloudRig Single Control 集成
+    cloudrig_single_control_param: EnumProperty(
+        name="Shape",
+        description="Select CloudRig Single Control shape parameter to update",
+        items=CLOUDRIG_SINGLE_CONTROL_ITEMS,
+        default='NONE',
+    )
+
+    # CloudRig Lattice 集成
+    cloudrig_lattice_param: EnumProperty(
+        name="Shape",
+        description="Select CloudRig Lattice shape parameter to update",
+        items=CLOUDRIG_LATTICE_ITEMS,
+        default='NONE',
+    )
+
+    # CloudRig Curve: With Hooks 集成
+    cloudrig_curve_hooks_param: EnumProperty(
+        name="Shape",
+        description="Select CloudRig Curve: With Hooks shape parameter to update",
+        items=CLOUDRIG_CURVE_HOOKS_ITEMS,
         default='NONE',
     )
 

--- a/props.py
+++ b/props.py
@@ -43,6 +43,37 @@ class CustomColorSet(bpy.types.PropertyGroup):
     )
 
 
+# CloudRig Spine: Cartoon 形状参数枚举
+CLOUDRIG_SPINE_TOON_ITEMS = [
+    ('NONE', "None", "Standard Bone Widget behavior"),
+    ('SHAPE_IK', "IK Shape", "Update spine_toon.shape_ik"),
+    ('SHAPE_IK_SECONDARY', "IK Secondary", "Update spine_toon.shape_ik_secondary"),
+    ('SHAPE_TORSO', "Torso", "Update spine_toon.shape_torso"),
+    ('SHAPE_FK', "FK Shape", "Update fk_chain.shape_fk"),
+    ('SHAPE_FK_ROOT', "FK Root Shape", "Update fk_chain.shape_fk_root"),
+]
+
+# CloudRig Limb: Biped Leg 形状参数枚举
+CLOUDRIG_LIMB_LEG_ITEMS = [
+    ('NONE', "None", "Standard Bone Widget behavior"),
+    ('LEG_STRETCH', "Stretch Shape", "Update chain.shape_stretch"),
+    ('LEG_STRETCH_ENDS', "Stretch Ends", "Update chain.shape_stretch_ends"),
+    ('LEG_FK', "FK Shape", "Update fk_chain.shape_fk"),
+    ('LEG_FK_ROOT', "FK Root Shape", "Update fk_chain.shape_fk_root"),
+    ('LEG_IK_MASTER', "IK Master", "Update ik_chain.shape_ik_master"),
+    ('LEG_IK_FIRST', "First IK", "Update ik_chain.shape_ik_first"),
+    ('LEG_IK_POLE', "IK Pole", "Update ik_chain.shape_ik_pole"),
+    ('LEG_FOOT_ROLL', "Foot Roll", "Update leg.shape_footroll"),
+]
+
+# 组件类型枚举
+CLOUDRIG_COMPONENT_TYPE_ITEMS = [
+    ('NONE', "None", "No CloudRig component"),
+    ('SPINE_TOON', "Spine: Cartoon", "Spine Cartoon component"),
+    ('LIMB_LEG', "Limb: Biped Leg", "Limb Biped Leg component"),
+]
+
+
 class BW_Settings(PropertyGroup):
     live_update_on: BoolProperty(
         name="Live Update On",
@@ -66,6 +97,30 @@ class BW_Settings(PropertyGroup):
         description="Select a Bone Color",
         items=bone_color_items_short,  # get the themes minus the blank ones
         default=1,  # THEME01
+    )
+
+    # CloudRig 组件类型（自动检测）
+    cloudrig_component_type: EnumProperty(
+        name="Component",
+        description="Detected CloudRig component type",
+        items=CLOUDRIG_COMPONENT_TYPE_ITEMS,
+        default='NONE',
+    )
+
+    # CloudRig Spine: Cartoon 集成
+    cloudrig_spine_toon_param: EnumProperty(
+        name="Shape",
+        description="Select CloudRig Spine: Cartoon shape parameter to update",
+        items=CLOUDRIG_SPINE_TOON_ITEMS,
+        default='NONE',
+    )
+
+    # CloudRig Limb: Biped Leg 集成
+    cloudrig_limb_leg_param: EnumProperty(
+        name="Shape",
+        description="Select CloudRig Limb: Biped Leg shape parameter to update",
+        items=CLOUDRIG_LIMB_LEG_ITEMS,
+        default='NONE',
     )
 
     # Nested Property Groups


### PR DESCRIPTION
## Problem
CloudRig and Rigify have fundamentally different approaches to custom bone widgets:

- **Rigify**: One bone stores parameters for one custom widget
- **CloudRig**: One bone stores parameters for **multiple** custom widgets (multi-widget system)

The original BoneWidget does not support this architecture, making it incompatible with CloudRig workflows.

## Motivation
CloudRig is positioned to become the next-generation standard rigging system for Blender (potentially replacing Rigify as the legacy solution). Adding CloudRig compatibility ensures BoneWidget remains relevant as the ecosystem evolves.

## Solution
Implemented enum-based widget switching to handle CloudRig's multi-widget-per-bone design:

- Added enumeration dropdown to switch between different custom widgets stored on the same bone 
- [CloudRig works by providing multiple custom bone slots for each component. I assign a selection enum to every component, which allows me to choose and edit specific items.]
- Maintained backward compatibility with existing Rigify rigs

## Testing
- Tested on Blender [5.1 stable]
- Verified with CloudRig [2.2.19] rigs
- Confirmed Rigify rigs still work as expected

## Screenshots
<img width="655" height="463" alt="image" src="https://github.com/user-attachments/assets/0de161fb-eec5-48b0-921a-16ac0ed8134c" />
<img width="902" height="687" alt="image" src="https://github.com/user-attachments/assets/c26cbe7e-0547-4d29-b38e-87bc2b2b2f49" />
